### PR TITLE
Tensorflow 2.0 Compliant Addition

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -124,7 +124,7 @@ def _extract_metric_update_ops( eval_dict ):
 
 def _get_config():
     """Setup session config to soften device placement"""
-    device_config=tf.ConfigProto(
+    device_config=tf.compat.v1.ConfigProto(
         allow_soft_placement=True, 
         log_device_placement=False)
 
@@ -136,7 +136,7 @@ def main(argv=None):
     dataset = _get_input()
 
     # Extract input tensors for evaluation
-    iterator = dataset.make_one_shot_iterator()
+    iterator = tf.compat.v1.data.make_one_shot_iterator(dataset)
     features, labels = iterator.get_next()
 
     # Construct the evaluation function 
@@ -155,7 +155,7 @@ def main(argv=None):
     stop_hook = tf.contrib.training.StopAfterNEvalsHook( 1 )
 
     # Create summaries of values added to tf.GraphKeys.SUMMARIES  
-    summary_writer = tf.summary.FileWriter (os.path.join(FLAGS.model,
+    summary_writer = tf.compat.v1.summary.FileWriter (os.path.join(FLAGS.model,
                                                          FLAGS.output))
     summary_hook = tf.contrib.training.SummaryAtEndHook(summary_writer=
                                                         summary_writer)
@@ -167,4 +167,4 @@ def main(argv=None):
         eval_interval_secs= FLAGS.eval_interval_secs )
 
 if __name__ == '__main__':
-    tf.app.run()   
+    tf.compat.v1.app.run()   

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -22,44 +22,47 @@
 import os
 import tensorflow as tf
 from tensorflow.python.ops import control_flow_ops
+import evaluation as evaluation
 import six
 import model_fn
 import pipeline
 import filters
 
+tf.compat.v1.disable_eager_execution()
+
 # Filters out information to just show a stream of results
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
-FLAGS = tf.app.flags.FLAGS
+FLAGS = tf.compat.v1.app.flags.FLAGS
 
 
-tf.app.flags.DEFINE_integer( 'batch_size',2**9,
+tf.compat.v1.app.flags.DEFINE_integer( 'batch_size',2**9,
                              """Eval batch size""" )
-tf.app.flags.DEFINE_integer('eval_interval_secs', 120,
+tf.compat.v1.app.flags.DEFINE_integer('eval_interval_secs', 120,
                              """Time between test runs""")
 
-tf.app.flags.DEFINE_string( 'model','../data/model',
+tf.compat.v1.app.flags.DEFINE_string( 'model','../data/model',
                             """Directory for event logs and checkpoints""" )
-tf.app.flags.DEFINE_string( 'output','test',
+tf.compat.v1.app.flags.DEFINE_string( 'output','test',
                             """Sub-directory of model for test summary events""" )
 
-tf.app.flags.DEFINE_string( 'test_path','../data/',
+tf.compat.v1.app.flags.DEFINE_string( 'test_path','../data/',
                             """Base directory for test/validation data""" )
-tf.app.flags.DEFINE_string( 'filename_pattern','val/words-*',
+tf.compat.v1.app.flags.DEFINE_string( 'filename_pattern','val/words-*',
                             """File pattern for input data""" )
-tf.app.flags.DEFINE_integer( 'num_input_threads',4,
+tf.compat.v1.app.flags.DEFINE_integer( 'num_input_threads',4,
                              """Number of readers for input data""" )
 
-tf.app.flags.DEFINE_integer('min_image_width',None,
+tf.compat.v1.app.flags.DEFINE_integer('min_image_width',None,
                             """Minimum allowable input image width""")
-tf.app.flags.DEFINE_integer('max_image_width',None,
+tf.compat.v1.app.flags.DEFINE_integer('max_image_width',None,
                             """Maximum allowable input image width""")
-tf.app.flags.DEFINE_integer('min_string_length',None,
+tf.compat.v1.app.flags.DEFINE_integer('min_string_length',None,
                             """Minimum allowable input string length""")
-tf.app.flags.DEFINE_integer('max_string_length',None,
+tf.compat.v1.app.flags.DEFINE_integer('max_string_length',None,
                             """Maximum allowable input string_length""")
 
-tf.app.flags.DEFINE_boolean('bucket_data',False,
+tf.compat.v1.app.flags.DEFINE_boolean('bucket_data',False,
                             """Bucket training data by width for efficiency""")
 
 
@@ -152,16 +155,16 @@ def main(argv=None):
         estimator_spec.eval_metric_ops)
   
     # Specify to evaluate N number of batches (in this case N==1)
-    stop_hook = tf.contrib.training.StopAfterNEvalsHook( 1 )
+    stop_hook = evaluation._StopAfterNEvalsHook( 1 )
 
     # Create summaries of values added to tf.GraphKeys.SUMMARIES  
     summary_writer = tf.compat.v1.summary.FileWriter (os.path.join(FLAGS.model,
                                                          FLAGS.output))
-    summary_hook = tf.contrib.training.SummaryAtEndHook(summary_writer=
+    summary_hook = evaluation.SummaryAtEndHook(summary_writer=
                                                         summary_writer)
     
     # Evaluate repeatedly once a new checkpoint is found
-    tf.contrib.training.evaluate_repeatedly(
+    evaluation.evaluate_repeatedly(
         checkpoint_dir=FLAGS.model,eval_ops=update_op, final_ops=value_ops, 
         hooks = [stop_hook, summary_hook], config=_get_config(), 
         eval_interval_secs= FLAGS.eval_interval_secs )

--- a/src/mjsynth-tfrecord.py
+++ b/src/mjsynth-tfrecord.py
@@ -29,7 +29,7 @@ The Example proto contains the following fields:
   image/labels: list containing the sequence labels for the image text
   image/text: string specifying the human-readable version of the text
 """
-jpeg_data = tf.placeholder( dtype=tf.string )
+jpeg_data = tf.compat.v1.placeholder( dtype=tf.string )
 jpeg_decoder = tf.image.decode_jpeg( jpeg_data,channels=1 )
 
 kernel_sizes = [3,3,3,3,3,3] # CNN kernels for image reduction
@@ -57,9 +57,9 @@ seq_lens = [calc_seq_len( w ) for w in range( 1024 )]
 def gen_data( input_base_dir, image_list_filename, output_filebase, 
               num_shards=1000, start_shard=0 ):
     """ Generate several shards worth of TFRecord data """
-    session_config = tf.ConfigProto()
+    session_config = tf.compat.v1.ConfigProto()
     session_config.gpu_options.allow_growth=True
-    sess = tf.Session( config=session_config )
+    sess = tf.compat.v1.Session( config=session_config )
     image_filenames = get_image_filenames( 
         os.path.join( input_base_dir,
                       image_list_filename ) )
@@ -76,15 +76,15 @@ def gen_data( input_base_dir, image_list_filename, output_filebase,
         out_filename = output_filebase+'-'+(shard_format % i)+'.tfrecord'
         if os.path.isfile( out_filename ): # Don't recreate data if restarting
             continue
-        print str( i ), 'of', str( num_shards ),\
-            '[', str( start ), ':', str( end ), ']', out_filename
+        print (str( i ), 'of', str( num_shards ),\
+            '[', str( start ), ':', str( end ), ']', out_filename)
         gen_shard( sess, input_base_dir, 
                    image_filenames[start:end], out_filename )
 
     # Clean up writing last shard
     start = num_shards * images_per_shard
     out_filename = output_filebase+'-'+(shard_format % num_shards)+'.tfrecord'
-    print str(i),'of',str(num_shards),'[',str(start),':]',out_filename
+    print (str(i),'of',str(num_shards),'[',str(start),':]',out_filename)
     gen_shard(sess, input_base_dir, image_filenames[start:], out_filename)
 
     sess.close()
@@ -92,7 +92,7 @@ def gen_data( input_base_dir, image_list_filename, output_filebase,
     
 def gen_shard( sess, input_base_dir, image_filenames, output_filename ):
     """Create a TFRecord file from a list of image filenames"""
-    writer = tf.python_io.TFRecordWriter( output_filename )
+    writer = tf.io.TFRecordWriter( output_filename )
     
     for filename in image_filenames:
         path_filename = os.path.join( input_base_dir, filename )
@@ -130,7 +130,7 @@ def get_image_filenames( image_list_filename ):
 
 def get_image( sess, filename ):
     """Given path to an image file, load its data and size"""
-    with tf.gfile.GFile( filename, 'rb' ) as f:
+    with tf.io.gfile.GFile( filename, 'rb' ) as f:
         image_data = f.read()
     image = sess.run( jpeg_decoder, feed_dict={ jpeg_data: image_data } )
     height = image.shape[0]

--- a/src/model.py
+++ b/src/model.py
@@ -20,7 +20,7 @@
 #   training) and decoding (for prediction/evaluation).
 
 import tensorflow as tf
-from tensorflow.contrib import learn
+import rnn as rnn
 
 # Layer params:   Filts K  Padding  Name     BatchNorm?
 layer_params = [ [  64, 3, 'valid', 'conv1', False], 
@@ -45,10 +45,10 @@ def conv_layer( bottom, params, training ):
     else:
         activation = tf.nn.relu
 
-    kernel_initializer = tf.contrib.layers.variance_scaling_initializer()
-    bias_initializer = tf.constant_initializer( value=0.0 )
+    kernel_initializer = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
+    bias_initializer = tf.compat.v1.constant_initializer( value=0.0 )
 
-    top = tf.layers.conv2d( bottom, 
+    top = tf.compat.v1.layers.conv2d( bottom, 
                             filters=params[0],
                             kernel_size=params[1],
                             padding=params[2],
@@ -65,7 +65,7 @@ def conv_layer( bottom, params, training ):
 
 def pool_layer( bottom, wpool, padding, name ):
     """Short function to build a pooling layer with less syntax"""
-    top = tf.layers.max_pooling2d( bottom, 
+    top = tf.compat.v1.layers.max_pooling2d( bottom, 
                                    2, 
                                    [2, wpool], 
                                    padding=padding, 
@@ -75,7 +75,7 @@ def pool_layer( bottom, wpool, padding, name ):
 
 def norm_layer( bottom, training, name):
     """Short function to build a batch normalization layer with less syntax"""
-    top = tf.layers.batch_normalization( bottom, 
+    top = tf.compat.v1.layers.batch_normalization( bottom, 
                                          axis=3, # channels last
                                          training=training,
                                          name=name )
@@ -87,10 +87,10 @@ def convnet_layers( inputs, widths, mode ):
     Build convolutional network layers attached to the given input tensor
     """
 
-    training = (mode == learn.ModeKeys.TRAIN)
+    training = (mode == tf.estimator.ModeKeys.TRAIN)
 
     # inputs should have shape [ ?, 32, ?, 1 ]
-    with tf.variable_scope( "convnet" ): # h,w
+    with tf.compat.v1.variable_scope( "convnet" ): # h,w
         
         conv1 = conv_layer( inputs, layer_params[0], training ) # 30,30
         conv2 = conv_layer( conv1, layer_params[1], training )  # 30,30
@@ -103,7 +103,7 @@ def convnet_layers( inputs, widths, mode ):
         pool6 = pool_layer( conv6, 1, 'valid', 'pool6')         # 3,13
         conv7 = conv_layer( pool6, layer_params[6], training )  # 3,13
         conv8 = conv_layer( conv7, layer_params[7], training )  # 3,13
-        pool8 = tf.layers.max_pooling2d( conv8, [3, 1], [3, 1], 
+        pool8 = tf.compat.v1.layers.max_pooling2d( conv8, [3, 1], [3, 1], 
                                          padding='valid', 
                                          name='pool8' )         # 1,13
         # squeeze row dim
@@ -121,92 +121,74 @@ def get_sequence_lengths( widths ):
     """Tensor calculating output sequence length from original image widths"""
     kernel_sizes = [params[1] for params in layer_params]
 
-    with tf.variable_scope("sequence_length"):
+    with tf.compat.v1.variable_scope("sequence_length"):
         conv1_trim = tf.constant( 2 * (kernel_sizes[0] // 2),
                                   dtype=tf.int32,
                                   name='conv1_trim' )
         one = tf.constant( 1, dtype=tf.int32, name='one' )
         two = tf.constant( 2, dtype=tf.int32, name='two' )
         after_conv1 = tf.subtract( widths, conv1_trim, name='after_conv1' )
-        after_pool2 = tf.floor_div( after_conv1, two, name='after_pool2' )
+        after_pool2 = tf.math.floordiv( after_conv1, two, name='after_pool2' )
         after_pool4 = tf.subtract( after_pool2, one, name='after_pool4' )
         after_pool6 = tf.subtract( after_pool4, one, name='after_pool6' ) 
         after_pool8 = tf.identity( after_pool6, name='after_pool8' )
     return after_pool8
 
-
 def rnn_layer( bottom_sequence, sequence_length, rnn_size, scope ):
     """Build bidirectional (concatenated output) RNN layer"""
 
-    weight_initializer = tf.truncated_normal_initializer( stddev=0.01 )
+    weight_initializer = tf.compat.v1.keras.initializers.TruncatedNormal( stddev=0.01 )
 
     # Default activation is tanh
-    cell_fw = tf.contrib.cudnn_rnn.CudnnCompatibleLSTMCell( rnn_size )
-    cell_bw = tf.contrib.cudnn_rnn.CudnnCompatibleLSTMCell( rnn_size )
+    cell_fw = tf.keras.layers.LSTMCell(units = rnn_size)
+    cell_bw = tf.keras.layers.LSTMCell(units = rnn_size)
 
-    # Pre-CUDNN (slower) alternatve. Default activation is tanh .
-    #cell_fw = tf.contrib.rnn.LSTMCell( rnn_size, 
-    #                                   initializer=weight_initializer)
-    #cell_bw = tf.contrib.rnn.LSTMCell( rnn_size, 
-    #                                   initializer=weight_initializer)
+    rnn_output,_ = rnn.bidirectional_dynamic_rnn(
+            cell_fw, 
+            cell_bw, 
+            bottom_sequence,
+            sequence_length=sequence_length,
+            time_major=True,
+            dtype=tf.float32,
+            scope=scope )
 
-    # Include?
-    #cell_fw = tf.contrib.rnn.DropoutWrapper( cell_fw, 
-    #                                         input_keep_prob=dropout_rate )
-    #cell_bw = tf.contrib.rnn.DropoutWrapper( cell_bw, 
-    #                                         input_keep_prob=dropout_rate )
-    
-    rnn_output,_ = tf.nn.bidirectional_dynamic_rnn(
-        cell_fw, 
-        cell_bw, 
-        bottom_sequence,
-        sequence_length=sequence_length,
-        time_major=True,
-        dtype=tf.float32,
-        scope=scope )
-    
-    # Concatenation allows a single output op because [A B]*[x;y] = Ax+By
-    # [ paddedSeqLen batchSize 2*rnn_size]
-    rnn_output_stack = tf.concat( rnn_output, 2, name='output_stack' )
-    
-    return rnn_output_stack
-
+    return tf.concat(rnn_output, 2, name='output_stack')
 
 def rnn_layers( features, sequence_length, num_classes ):
     """Build a stack of RNN layers from input features"""
 
     # Input features is [batchSize paddedSeqLen numFeatures]
     logit_activation = tf.nn.relu
-    weight_initializer = tf.contrib.layers.variance_scaling_initializer()
-    bias_initializer = tf.constant_initializer( value=0.0 )
+    weight_initializer = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
+    bias_initializer = tf.compat.v1.constant_initializer( value=0.0 )
 
-    with tf.variable_scope( "rnn" ):
+    with tf.compat.v1.variable_scope( "rnn" ):
         # Transpose to time-major order for efficiency
-        rnn_sequence = tf.transpose( features, 
+        rnn_sequence = tf.transpose( a=features, 
                                      perm=[1, 0, 2], 
                                      name='time_major' )
         rnn1 = rnn_layer( rnn_sequence, sequence_length, rnn_size, 'bdrnn1' )
         rnn2 = rnn_layer( rnn1, sequence_length, rnn_size, 'bdrnn2' )
-        rnn_logits = tf.layers.dense( rnn2, 
-                                      num_classes+1, 
+        rnn_logits = tf.keras.layers.Dense(
+                                      units = num_classes+1, 
                                       activation=logit_activation,
                                       kernel_initializer=weight_initializer,
                                       bias_initializer=bias_initializer,
-                                      name='logits' )
+                                      name='logits' )(rnn2)
         return rnn_logits
     
 
 def ctc_loss_layer( rnn_logits, sequence_labels, sequence_length,
                     reduce_mean=True ):
     """Build CTC Loss layer for training"""
-    losses = tf.nn.ctc_loss( sequence_labels, 
+    losses = tf.compat.v1.nn.ctc_loss( sequence_labels, 
                              rnn_logits, 
                              sequence_length,
                              time_major=True, 
                              ignore_longer_outputs_than_inputs=True )
     if (reduce_mean):
-        loss = tf.reduce_mean( losses )
+        loss = tf.reduce_mean( input_tensor=losses )
     else:
-        loss = tf.reduce_sum( losses )
+        loss = tf.reduce_sum( input_tensor=losses )
 
     return loss

--- a/src/model_fn.py
+++ b/src/model_fn.py
@@ -165,7 +165,7 @@ def _get_loss_ops( batch_loss ):
     var_collections=[tf.compat.v1.GraphKeys.LOCAL_VARIABLES]
 
     # Variable to tally across batches (all initially zero)
-    total_loss = tf.Variable( 0, trainable=False,
+    total_loss = tf.compat.v1.Variable( 0, trainable=False,
                               name='total_loss',
                               dtype=tf.float32,
                               collections=var_collections )
@@ -183,12 +183,12 @@ def _get_label_err_ops( batch_num_label_error, batch_total_labels ):
     var_collections=[tf.compat.v1.GraphKeys.LOCAL_VARIABLES]
 
     # Variables to tally across batches (all initially zero)
-    total_num_label_errors = tf.Variable( 0, trainable=False,
+    total_num_label_errors = tf.compat.v1.Variable( 0, trainable=False,
                                           name='total_num_label_errors',
                                           dtype=tf.int64,
                                           collections=var_collections )
 
-    total_num_labels =  tf.Variable( 0, trainable=False,
+    total_num_labels =  tf.compat.v1.Variable( 0, trainable=False,
                                      name='total_num_labels',
                                      dtype=tf.int64,
                                      collections=var_collections )
@@ -217,12 +217,12 @@ def _get_seq_err_ops( batch_num_sequence_errors, label_length ):
     var_collections=[tf.compat.v1.GraphKeys.LOCAL_VARIABLES]
 
     # Variables to tally across batches (all initially zero)
-    total_num_sequence_errors =  tf.Variable( 0, trainable=False,
+    total_num_sequence_errors =  tf.compat.v1.Variable( 0, trainable=False,
                                               name='total_num_sequence_errors',
                                               dtype=tf.int64,
                                               collections=var_collections )
 
-    total_num_sequences =  tf.Variable( 0, trainable=False,
+    total_num_sequences =  tf.compat.v1.Variable( 0, trainable=False,
                                         name='total_num_sequences',
                                         dtype=tf.int64,
                                         collections=var_collections )

--- a/src/optimizers.py
+++ b/src/optimizers.py
@@ -1,0 +1,440 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Optimizer ops for use in layers and tf.learn."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+
+#from tensorflow.contrib import framework as contrib_framework
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import random_ops
+from tensorflow.python.ops import variable_scope as vs
+from tensorflow.python.ops import variables as vars_
+from tensorflow.python.summary import summary
+from tensorflow.python.training import moving_averages
+from tensorflow.python.training import optimizer as optimizer_
+from tensorflow.python.training import training as train
+
+OPTIMIZER_CLS_NAMES = {
+    "Adagrad": train.AdagradOptimizer,
+    "Adam": train.AdamOptimizer,
+    "Ftrl": train.FtrlOptimizer,
+    "Momentum": lambda learning_rate: train.MomentumOptimizer(learning_rate, momentum=0.9),  # pylint: disable=line-too-long
+    "RMSProp": train.RMSPropOptimizer,
+    "SGD": train.GradientDescentOptimizer,
+}
+
+OPTIMIZER_SUMMARIES = [
+    "learning_rate",
+    "loss",
+    "gradients",
+    "gradient_norm",
+    "global_gradient_norm",
+]
+
+
+def optimize_loss(loss,
+                  global_step,
+                  learning_rate,
+                  optimizer,
+                  gradient_noise_scale=None,
+                  gradient_multipliers=None,
+                  clip_gradients=None,
+                  learning_rate_decay_fn=None,
+                  update_ops=None,
+                  variables=None,
+                  name=None,
+                  summaries=None,
+                  colocate_gradients_with_ops=False,
+                  increment_global_step=True):
+  """Given loss and parameters for optimizer, returns a training op.
+
+  Various ways of passing optimizers include:
+
+  - by string specifying the name of the optimizer. See OPTIMIZER_CLS_NAMES
+      for full list. E.g. `optimize_loss(..., optimizer='Adam')`.
+  - by function taking learning rate `Tensor` as argument and returning an
+      `Optimizer` instance. E.g. `optimize_loss(...,
+      optimizer=lambda lr: tf.compat.v1.train.MomentumOptimizer(lr,
+      momentum=0.5))`.
+    Alternatively, if `learning_rate` is `None`, the function takes no
+    arguments. E.g. `optimize_loss(..., learning_rate=None,
+      optimizer=lambda: tf.compat.v1.train.MomentumOptimizer(0.5,
+      momentum=0.5))`.
+  - by a subclass of `Optimizer` having a single-argument constructor
+      (the argument is the learning rate), such as AdamOptimizer or
+      AdagradOptimizer. E.g. `optimize_loss(...,
+      optimizer=tf.compat.v1.train.AdagradOptimizer)`.
+  - by an instance of a subclass of `Optimizer`.
+      E.g., `optimize_loss(...,
+      optimizer=tf.compat.v1.train.AdagradOptimizer(0.5))`.
+
+  Args:
+    loss: Scalar `Tensor`.
+    global_step: Scalar int `Tensor`, step counter to update on each step unless
+      `increment_global_step` is `False`. If not supplied, it will be fetched
+      from the default graph (see `tf.compat.v1.train.get_global_step` for
+      details). If it has not been created, no step will be incremented with
+      each weight update. `learning_rate_decay_fn` requires `global_step`.
+    learning_rate: float or `Tensor`, magnitude of update per each training
+      step. Can be `None`.
+    optimizer: string, class or optimizer instance, used as trainer. string
+      should be name of optimizer, like 'SGD', 'Adam', 'Adagrad'. Full list in
+      OPTIMIZER_CLS_NAMES constant. class should be sub-class of `tf.Optimizer`
+      that implements `compute_gradients` and `apply_gradients` functions.
+      optimizer instance should be instantiation of `tf.Optimizer` sub-class and
+      have `compute_gradients` and `apply_gradients` functions.
+    gradient_noise_scale: float or None, adds 0-mean normal noise scaled by this
+      value.
+    gradient_multipliers: dict of variables or variable names to floats. If
+      present, gradients for specified variables will be multiplied by given
+      constant.
+    clip_gradients: float, callable or `None`. If a float is provided, a global
+      clipping is applied to prevent the norm of the gradient from exceeding
+      this value. Alternatively, a callable can be provided, e.g.,
+      `adaptive_clipping_fn()`.  This callable takes a list of `(gradients,
+      variables)` tuples and returns the same thing with the gradients modified.
+    learning_rate_decay_fn: function, takes `learning_rate` and `global_step`
+      `Tensor`s, returns `Tensor`. Can be used to implement any learning rate
+      decay functions.
+                            For example: `tf.compat.v1.train.exponential_decay`.
+                              Ignored if `learning_rate` is not supplied.
+    update_ops: list of update `Operation`s to execute at each step. If `None`,
+      uses elements of UPDATE_OPS collection. The order of execution between
+      `update_ops` and `loss` is non-deterministic.
+    variables: list of variables to optimize or `None` to use all trainable
+      variables.
+    name: The name for this operation is used to scope operations and summaries.
+    summaries: List of internal quantities to visualize on tensorboard. If not
+      set, the loss, the learning rate, and the global norm of the gradients
+      will be reported. The complete list of possible values is in
+      OPTIMIZER_SUMMARIES.
+    colocate_gradients_with_ops: If True, try colocating gradients with the
+      corresponding op.
+    increment_global_step: Whether to increment `global_step`. If your model
+      calls `optimize_loss` multiple times per training step (e.g. to optimize
+      different parts of the model), use this arg to avoid incrementing
+      `global_step` more times than necessary.
+
+  Returns:
+    Training op.
+
+  Raises:
+    ValueError: if:
+        * `loss` is an invalid type or shape.
+        * `global_step` is an invalid type or shape.
+        * `learning_rate` is an invalid type or value.
+        * `optimizer` has the wrong type.
+        * `clip_gradients` is neither float nor callable.
+        * `learning_rate` and `learning_rate_decay_fn` are supplied, but no
+          `global_step` is available.
+        * `gradients` is empty.
+  """
+  loss = ops.convert_to_tensor(loss)
+  #contrib_framework.assert_scalar(loss)
+  if global_step is None:
+    global_step = train.get_global_step()
+  else:
+    train.assert_global_step(global_step)
+  with vs.variable_scope(name, "OptimizeLoss", [loss, global_step]):
+    # Update ops take UPDATE_OPS collection if not provided.
+    if update_ops is None:
+      update_ops = set(ops.get_collection(ops.GraphKeys.UPDATE_OPS))
+    # Make sure update ops are ran before computing loss.
+    if update_ops:
+      loss = control_flow_ops.with_dependencies(list(update_ops), loss)
+
+    # Learning rate variable, with possible decay.
+    lr = None
+    if learning_rate is not None:
+      if (isinstance(learning_rate, ops.Tensor) and
+          learning_rate.get_shape().ndims == 0):
+        lr = learning_rate
+      elif isinstance(learning_rate, float):
+        if learning_rate < 0.0:
+          raise ValueError("Invalid learning_rate %s.", learning_rate)
+        lr = vs.get_variable(
+            "learning_rate", [],
+            trainable=False,
+            initializer=init_ops.constant_initializer(learning_rate))
+      else:
+        raise ValueError("Learning rate should be 0d Tensor or float. "
+                         "Got %s of type %s" %
+                         (str(learning_rate), str(type(learning_rate))))
+    if summaries is None:
+      summaries = ["loss", "learning_rate", "global_gradient_norm"]
+    else:
+      for summ in summaries:
+        if summ not in OPTIMIZER_SUMMARIES:
+          raise ValueError("Summaries should be one of [%s], you provided %s." %
+                           (", ".join(OPTIMIZER_SUMMARIES), summ))
+    if learning_rate is not None and learning_rate_decay_fn is not None:
+      if global_step is None:
+        raise ValueError("global_step is required for learning_rate_decay_fn.")
+      lr = learning_rate_decay_fn(lr, global_step)
+      if "learning_rate" in summaries:
+        summary.scalar("learning_rate", lr)
+
+    # Create optimizer, given specified parameters.
+    if isinstance(optimizer, six.string_types):
+      if lr is None:
+        raise ValueError("Learning rate is None, but should be specified if "
+                         "optimizer is string (%s)." % optimizer)
+      if optimizer not in OPTIMIZER_CLS_NAMES:
+        raise ValueError(
+            "Optimizer name should be one of [%s], you provided %s." %
+            (", ".join(OPTIMIZER_CLS_NAMES), optimizer))
+      opt = OPTIMIZER_CLS_NAMES[optimizer](learning_rate=lr)
+    elif (isinstance(optimizer, type) and
+          issubclass(optimizer, optimizer_.Optimizer)):
+      if lr is None:
+        raise ValueError("Learning rate is None, but should be specified if "
+                         "optimizer is class (%s)." % optimizer)
+      opt = optimizer(learning_rate=lr)
+    elif isinstance(optimizer, optimizer_.Optimizer):
+      opt = optimizer
+    elif callable(optimizer):
+      if learning_rate is not None:
+        opt = optimizer(lr)
+      else:
+        opt = optimizer()
+      if not isinstance(opt, optimizer_.Optimizer):
+        raise ValueError("Unrecognized optimizer: function should return "
+                         "subclass of Optimizer. Got %s." % str(opt))
+    else:
+      raise ValueError("Unrecognized optimizer: should be string, "
+                       "subclass of Optimizer, instance of "
+                       "subclass of Optimizer or function with one argument. "
+                       "Got %s." % str(optimizer))
+
+    # All trainable variables, if specific variables are not specified.
+    if variables is None:
+      variables = vars_.trainable_variables()
+
+    # Compute gradients.
+    gradients = opt.compute_gradients(
+        loss,
+        variables,
+        colocate_gradients_with_ops=colocate_gradients_with_ops)
+
+    # Optionally add gradient noise.
+    if gradient_noise_scale is not None:
+      gradients = _add_scaled_noise_to_gradients(gradients,
+                                                 gradient_noise_scale)
+
+    # Multiply some gradients.
+    if gradient_multipliers is not None:
+      gradients = _multiply_gradients(gradients, gradient_multipliers)
+      if not gradients:
+        raise ValueError(
+            "Empty list of (gradient, var) pairs encountered. This is most "
+            "likely to be caused by an improper value of gradient_multipliers.")
+
+    if "global_gradient_norm" in summaries or "gradient_norm" in summaries:
+      summary.scalar("global_norm/gradient_norm",
+                     clip_ops.global_norm(list(zip(*gradients))[0]))
+
+    # Optionally clip gradients by global norm.
+    if isinstance(clip_gradients, float):
+      gradients = _clip_gradients_by_norm(gradients, clip_gradients)
+    elif callable(clip_gradients):
+      gradients = clip_gradients(gradients)
+    elif clip_gradients is not None:
+      raise ValueError("Unknown type %s for clip_gradients" %
+                       type(clip_gradients))
+
+    # Add scalar summary for loss.
+    if "loss" in summaries:
+      summary.scalar("loss", loss)
+
+    # Add histograms for variables, gradients and gradient norms.
+    for gradient, variable in gradients:
+      if isinstance(gradient, ops.IndexedSlices):
+        grad_values = gradient.values
+      else:
+        grad_values = gradient
+
+      if grad_values is not None:
+        var_name = variable.name.replace(":", "_")
+        if "gradients" in summaries:
+          summary.histogram("gradients/%s" % var_name, grad_values)
+        if "gradient_norm" in summaries:
+          summary.scalar("gradient_norm/%s" % var_name,
+                         clip_ops.global_norm([grad_values]))
+
+    if clip_gradients is not None and ("global_gradient_norm" in summaries or
+                                       "gradient_norm" in summaries):
+      summary.scalar("global_norm/clipped_gradient_norm",
+                     clip_ops.global_norm(list(zip(*gradients))[0]))
+
+    # Create gradient updates.
+    grad_updates = opt.apply_gradients(
+        gradients,
+        global_step=global_step if increment_global_step else None,
+        name="train")
+
+    # Ensure the train_tensor computes grad_updates.
+    train_tensor = control_flow_ops.with_dependencies([grad_updates], loss)
+
+    return train_tensor
+
+
+def _clip_gradients_by_norm(grads_and_vars, clip_gradients):
+  """Clips gradients by global norm."""
+  gradients, variables = zip(*grads_and_vars)
+  clipped_gradients, _ = clip_ops.clip_by_global_norm(gradients, clip_gradients)
+  return list(zip(clipped_gradients, variables))
+
+
+def _adaptive_max_norm(norm, std_factor, decay, global_step, epsilon, name):
+  """Find max_norm given norm and previous average."""
+  with vs.variable_scope(name, "AdaptiveMaxNorm", [norm]):
+    log_norm = math_ops.log(norm + epsilon)
+
+    def moving_average(name, value, decay):
+      moving_average_variable = vs.get_variable(
+          name,
+          shape=value.get_shape(),
+          dtype=value.dtype,
+          initializer=init_ops.zeros_initializer(),
+          trainable=False)
+      return moving_averages.assign_moving_average(
+          moving_average_variable, value, decay, zero_debias=False)
+
+    # quicker adaptation at the beginning
+    if global_step is not None:
+      n = math_ops.cast(global_step, dtypes.float32)
+      decay = math_ops.minimum(decay, n / (n + 1.))
+
+    # update averages
+    mean = moving_average("mean", log_norm, decay)
+    sq_mean = moving_average("sq_mean", math_ops.square(log_norm), decay)
+
+    variance = sq_mean - math_ops.square(mean)
+    std = math_ops.sqrt(math_ops.maximum(epsilon, variance))
+    max_norms = math_ops.exp(mean + std_factor * std)
+    return max_norms, mean
+
+
+def adaptive_clipping_fn(std_factor=2.,
+                         decay=0.95,
+                         static_max_norm=None,
+                         global_step=None,
+                         report_summary=False,
+                         epsilon=1e-8,
+                         name=None):
+  """Adapt the clipping value using statistics on the norms.
+
+  Implement adaptive gradient as presented in section 3.2.1 of
+  https://arxiv.org/abs/1412.1602.
+
+  Keeps a moving average of the mean and std of the log(norm) of the gradient.
+  If the norm exceeds `exp(mean + std_factor*std)` then all gradients will be
+  rescaled such that the global norm becomes `exp(mean)`.
+
+  Args:
+    std_factor: Python scaler (or tensor). `max_norm = exp(mean +
+      std_factor*std)`
+    decay: The smoothing factor of the moving averages.
+    static_max_norm: If provided, will threshold the norm to this value as an
+      extra safety.
+    global_step: Optional global_step. If provided, `decay = decay*n/(n+1)`.
+      This provides a quicker adaptation of the mean for the first steps.
+    report_summary: If `True`, will add histogram summaries of the `max_norm`.
+    epsilon: Small value chosen to avoid zero variance.
+    name: The name for this operation is used to scope operations and summaries.
+
+  Returns:
+    A function for applying gradient clipping.
+  """
+
+  def gradient_clipping(grads_and_vars):
+    """Internal function for adaptive clipping."""
+    grads, variables = zip(*grads_and_vars)
+
+    norm = clip_ops.global_norm(grads)
+
+    max_norm, log_mean = _adaptive_max_norm(norm, std_factor, decay,
+                                            global_step, epsilon, name)
+
+    # reports the max gradient norm for debugging
+    if report_summary:
+      summary.scalar("global_norm/adaptive_max_gradient_norm", max_norm)
+
+    # factor will be 1. if norm is smaller than max_norm
+    factor = array_ops.where(norm < max_norm, array_ops.ones_like(norm),
+                             math_ops.exp(log_mean) / norm)
+
+    if static_max_norm is not None:
+      factor = math_ops.minimum(static_max_norm / norm, factor)
+
+    # apply factor
+    clipped_grads = []
+    for grad in grads:
+      if grad is None:
+        clipped_grads.append(None)
+      elif isinstance(grad, ops.IndexedSlices):
+        clipped_grads.append(
+            ops.IndexedSlices(grad.values * factor, grad.indices,
+                              grad.dense_shape))
+      else:
+        clipped_grads.append(grad * factor)
+
+    return list(zip(clipped_grads, variables))
+
+  return gradient_clipping
+
+
+def _add_scaled_noise_to_gradients(grads_and_vars, gradient_noise_scale):
+  """Adds scaled noise from a 0-mean normal distribution to gradients."""
+  gradients, variables = zip(*grads_and_vars)
+  noisy_gradients = []
+  for gradient in gradients:
+    if gradient is None:
+      noisy_gradients.append(None)
+      continue
+    if isinstance(gradient, ops.IndexedSlices):
+      gradient_shape = gradient.dense_shape
+    else:
+      gradient_shape = gradient.get_shape()
+    noise = random_ops.truncated_normal(gradient_shape) * gradient_noise_scale
+    noisy_gradients.append(gradient + noise)
+  return list(zip(noisy_gradients, variables))
+
+
+def _multiply_gradients(grads_and_vars, gradient_multipliers):
+  """Multiply specified gradients."""
+  multiplied_grads_and_vars = []
+  for grad, var in grads_and_vars:
+    if (grad is not None and
+        (var in gradient_multipliers or var.name in gradient_multipliers)):
+      key = var if var in gradient_multipliers else var.name
+      multiplier = gradient_multipliers[key]
+      if isinstance(grad, ops.IndexedSlices):
+        grad_values = grad.values * multiplier
+        grad = ops.IndexedSlices(grad_values, grad.indices, grad.dense_shape)
+      else:
+        grad *= math_ops.cast(multiplier, grad.dtype)
+    multiplied_grads_and_vars.append((grad, var))
+  return multiplied_grads_and_vars

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -100,7 +100,7 @@ def get_data( use_static_data,
     else:
         # Dynamically pad batches to match largest in batch
         dataset = dataset.padded_batch( batch_size, 
-                                        padded_shapes=dataset.output_shapes )
+                                        padded_shapes=tf.compat.v1.data.get_output_shapes(dataset))
     
     # Update to account for batching
     num_buffered_elements = num_threads * 2
@@ -156,7 +156,7 @@ def normalize_image( image ):
     """Normalize: convert uint8 RGB to gray, rescale, and resize image height"""
 
     # Convert to grayscale
-    image = tf.image.rgb_to_grayscale( image )
+    #image = tf.image.rgb_to_grayscale( image )
     
     # Rescale from uint8([0,255]) to float([-0.5,0.5])
     image = rescale_image( image )

--- a/src/rnn.py
+++ b/src/rnn.py
@@ -1,0 +1,1635 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""RNN helpers for TensorFlow models."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.framework import tensor_util
+from tensorflow.python.keras.engine import base_layer
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import control_flow_util
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import rnn_cell_impl
+from tensorflow.python.ops import tensor_array_ops
+from tensorflow.python.ops import variable_scope as vs
+from tensorflow.python.util import deprecation
+from tensorflow.python.util import nest
+from tensorflow.python.util.tf_export import tf_export
+
+# pylint: disable=protected-access
+_concat = rnn_cell_impl._concat
+# pylint: enable=protected-access
+
+
+def _transpose_batch_time(x):
+  """Transposes the batch and time dimensions of a Tensor.
+
+  If the input tensor has rank < 2 it returns the original tensor. Retains as
+  much of the static shape information as possible.
+
+  Args:
+    x: A Tensor.
+
+  Returns:
+    x transposed along the first two dimensions.
+  """
+  x_static_shape = x.get_shape()
+  if x_static_shape.rank is not None and x_static_shape.rank < 2:
+    return x
+
+  x_rank = array_ops.rank(x)
+  x_t = array_ops.transpose(
+      x, array_ops.concat(([1, 0], math_ops.range(2, x_rank)), axis=0))
+  x_t.set_shape(
+      tensor_shape.TensorShape(
+          [x_static_shape.dims[1].value,
+           x_static_shape.dims[0].value]).concatenate(x_static_shape[2:]))
+  return x_t
+
+
+def _best_effort_input_batch_size(flat_input):
+  """Get static input batch size if available, with fallback to the dynamic one.
+
+  Args:
+    flat_input: An iterable of time major input Tensors of shape `[max_time,
+      batch_size, ...]`. All inputs should have compatible batch sizes.
+
+  Returns:
+    The batch size in Python integer if available, or a scalar Tensor otherwise.
+
+  Raises:
+    ValueError: if there is any input with an invalid shape.
+  """
+  for input_ in flat_input:
+    shape = input_.shape
+    if shape.rank is None:
+      continue
+    if shape.rank < 2:
+      raise ValueError("Expected input tensor %s to have rank at least 2" %
+                       input_)
+    batch_size = shape.dims[1].value
+    if batch_size is not None:
+      return batch_size
+  # Fallback to the dynamic batch size of the first input.
+  return array_ops.shape(flat_input[0])[1]
+
+
+def _infer_state_dtype(explicit_dtype, state):
+  """Infer the dtype of an RNN state.
+
+  Args:
+    explicit_dtype: explicitly declared dtype or None.
+    state: RNN's hidden state. Must be a Tensor or a nested iterable containing
+      Tensors.
+
+  Returns:
+    dtype: inferred dtype of hidden state.
+
+  Raises:
+    ValueError: if `state` has heterogeneous dtypes or is empty.
+  """
+  if explicit_dtype is not None:
+    return explicit_dtype
+  elif nest.is_sequence(state):
+    inferred_dtypes = [element.dtype for element in nest.flatten(state)]
+    if not inferred_dtypes:
+      raise ValueError("Unable to infer dtype from empty state.")
+    all_same = all(x == inferred_dtypes[0] for x in inferred_dtypes)
+    if not all_same:
+      raise ValueError(
+          "State has tensors of different inferred_dtypes. Unable to infer a "
+          "single representative dtype.")
+    return inferred_dtypes[0]
+  else:
+    return state.dtype
+
+
+def _maybe_tensor_shape_from_tensor(shape):
+  if isinstance(shape, ops.Tensor):
+    return tensor_shape.as_shape(tensor_util.constant_value(shape))
+  else:
+    return shape
+
+
+def _should_cache():
+  """Returns True if a default caching device should be set, otherwise False."""
+  if context.executing_eagerly():
+    return False
+  # Don't set a caching device when running in a loop, since it is possible that
+  # train steps could be wrapped in a tf.while_loop. In that scenario caching
+  # prevents forward computations in loop iterations from re-reading the
+  # updated weights.
+  ctxt = ops.get_default_graph()._get_control_flow_context()  # pylint: disable=protected-access
+  return control_flow_util.GetContainingWhileContext(ctxt) is None
+
+
+def _is_keras_rnn_cell(rnn_cell):
+  """Check whether the cell is a Keras RNN cell.
+
+  The Keras RNN cell accept the state as a list even the state is a single
+  tensor, whereas the TF RNN cell does not wrap single state tensor in list.
+  This behavior difference should be unified in future version.
+
+  Args:
+    rnn_cell: An RNN cell instance that either follow the Keras interface or TF
+      RNN interface.
+
+  Returns:
+    Boolean, whether the cell is an Keras RNN cell.
+  """
+  # Cell type check is not strict enough since there are cells created by other
+  # library like Deepmind that didn't inherit tf.nn.rnn_cell.RNNCell.
+  # Keras cells never had zero_state method, which was from the original
+  # interface from TF RNN cell.
+  return (not isinstance(rnn_cell, rnn_cell_impl.RNNCell) and
+          isinstance(rnn_cell, base_layer.Layer) and
+          getattr(rnn_cell, "zero_state", None) is None)
+
+
+# pylint: disable=unused-argument
+def _rnn_step(time,
+              sequence_length,
+              min_sequence_length,
+              max_sequence_length,
+              zero_output,
+              state,
+              call_cell,
+              state_size,
+              skip_conditionals=False):
+  """Calculate one step of a dynamic RNN minibatch.
+
+  Returns an (output, state) pair conditioned on `sequence_length`.
+  When skip_conditionals=False, the pseudocode is something like:
+
+  if t >= max_sequence_length:
+    return (zero_output, state)
+  if t < min_sequence_length:
+    return call_cell()
+
+  # Selectively output zeros or output, old state or new state depending
+  # on whether we've finished calculating each row.
+  new_output, new_state = call_cell()
+  final_output = np.vstack([
+    zero_output if time >= sequence_length[r] else new_output_r
+    for r, new_output_r in enumerate(new_output)
+  ])
+  final_state = np.vstack([
+    state[r] if time >= sequence_length[r] else new_state_r
+    for r, new_state_r in enumerate(new_state)
+  ])
+  return (final_output, final_state)
+
+  Args:
+    time: int32 `Tensor` scalar.
+    sequence_length: int32 `Tensor` vector of size [batch_size].
+    min_sequence_length: int32 `Tensor` scalar, min of sequence_length.
+    max_sequence_length: int32 `Tensor` scalar, max of sequence_length.
+    zero_output: `Tensor` vector of shape [output_size].
+    state: Either a single `Tensor` matrix of shape `[batch_size, state_size]`,
+      or a list/tuple of such tensors.
+    call_cell: lambda returning tuple of (new_output, new_state) where
+      new_output is a `Tensor` matrix of shape `[batch_size, output_size]`.
+      new_state is a `Tensor` matrix of shape `[batch_size, state_size]`.
+    state_size: The `cell.state_size` associated with the state.
+    skip_conditionals: Python bool, whether to skip using the conditional
+      calculations.  This is useful for `dynamic_rnn`, where the input tensor
+      matches `max_sequence_length`, and using conditionals just slows
+      everything down.
+
+  Returns:
+    A tuple of (`final_output`, `final_state`) as given by the pseudocode above:
+      final_output is a `Tensor` matrix of shape [batch_size, output_size]
+      final_state is either a single `Tensor` matrix, or a tuple of such
+        matrices (matching length and shapes of input `state`).
+
+  Raises:
+    ValueError: If the cell returns a state tuple whose length does not match
+      that returned by `state_size`.
+  """
+
+  # Convert state to a list for ease of use
+  flat_state = nest.flatten(state)
+  flat_zero_output = nest.flatten(zero_output)
+
+  # Vector describing which batch entries are finished.
+  copy_cond = time >= sequence_length
+
+  def _copy_one_through(output, new_output):
+    # TensorArray and scalar get passed through.
+    if isinstance(output, tensor_array_ops.TensorArray):
+      return new_output
+    if output.shape.rank == 0:
+      return new_output
+    # Otherwise propagate the old or the new value.
+    with ops.colocate_with(new_output):
+      return array_ops.where(copy_cond, output, new_output)
+
+  def _copy_some_through(flat_new_output, flat_new_state):
+    # Use broadcasting select to determine which values should get
+    # the previous state & zero output, and which values should get
+    # a calculated state & output.
+    flat_new_output = [
+        _copy_one_through(zero_output, new_output)
+        for zero_output, new_output in zip(flat_zero_output, flat_new_output)
+    ]
+    flat_new_state = [
+        _copy_one_through(state, new_state)
+        for state, new_state in zip(flat_state, flat_new_state)
+    ]
+    return flat_new_output + flat_new_state
+
+  def _maybe_copy_some_through():
+    """Run RNN step.  Pass through either no or some past state."""
+    new_output, new_state = call_cell()
+
+    nest.assert_same_structure(zero_output, new_output)
+    nest.assert_same_structure(state, new_state)
+
+    flat_new_state = nest.flatten(new_state)
+    flat_new_output = nest.flatten(new_output)
+    return control_flow_ops.cond(
+        # if t < min_seq_len: calculate and return everything
+        time < min_sequence_length,
+        lambda: flat_new_output + flat_new_state,
+        # else copy some of it through
+        lambda: _copy_some_through(flat_new_output, flat_new_state))
+
+  # TODO(ebrevdo): skipping these conditionals may cause a slowdown,
+  # but benefits from removing cond() and its gradient.  We should
+  # profile with and without this switch here.
+  if skip_conditionals:
+    # Instead of using conditionals, perform the selective copy at all time
+    # steps.  This is faster when max_seq_len is equal to the number of unrolls
+    # (which is typical for dynamic_rnn).
+    new_output, new_state = call_cell()
+    nest.assert_same_structure(zero_output, new_output)
+    nest.assert_same_structure(state, new_state)
+    new_state = nest.flatten(new_state)
+    new_output = nest.flatten(new_output)
+    final_output_and_state = _copy_some_through(new_output, new_state)
+  else:
+    empty_update = lambda: flat_zero_output + flat_state
+    final_output_and_state = control_flow_ops.cond(
+        # if t >= max_seq_len: copy all state through, output zeros
+        time >= max_sequence_length,
+        empty_update,
+        # otherwise calculation is required: copy some or all of it through
+        _maybe_copy_some_through)
+
+  if len(final_output_and_state) != len(flat_zero_output) + len(flat_state):
+    raise ValueError("Internal error: state and output were not concatenated "
+                     "correctly.")
+  final_output = final_output_and_state[:len(flat_zero_output)]
+  final_state = final_output_and_state[len(flat_zero_output):]
+
+  for output, flat_output in zip(final_output, flat_zero_output):
+    output.set_shape(flat_output.get_shape())
+  for substate, flat_substate in zip(final_state, flat_state):
+    if not isinstance(substate, tensor_array_ops.TensorArray):
+      substate.set_shape(flat_substate.get_shape())
+
+  final_output = nest.pack_sequence_as(
+      structure=zero_output, flat_sequence=final_output)
+  final_state = nest.pack_sequence_as(
+      structure=state, flat_sequence=final_state)
+
+  return final_output, final_state
+
+
+def _reverse_seq(input_seq, lengths):
+  """Reverse a list of Tensors up to specified lengths.
+
+  Args:
+    input_seq: Sequence of seq_len tensors of dimension (batch_size, n_features)
+      or nested tuples of tensors.
+    lengths:   A `Tensor` of dimension batch_size, containing lengths for each
+      sequence in the batch. If "None" is specified, simply reverses the list.
+
+  Returns:
+    time-reversed sequence
+  """
+  if lengths is None:
+    return list(reversed(input_seq))
+
+  flat_input_seq = tuple(nest.flatten(input_) for input_ in input_seq)
+
+  flat_results = [[] for _ in range(len(input_seq))]
+  for sequence in zip(*flat_input_seq):
+    input_shape = tensor_shape.unknown_shape(rank=sequence[0].get_shape().rank)
+    for input_ in sequence:
+      input_shape.merge_with(input_.get_shape())
+      input_.set_shape(input_shape)
+
+    # Join into (time, batch_size, depth)
+    s_joined = array_ops.stack(sequence)
+
+    # Reverse along dimension 0
+    s_reversed = array_ops.reverse_sequence(s_joined, lengths, 0, 1)
+    # Split again into list
+    result = array_ops.unstack(s_reversed)
+    for r, flat_result in zip(result, flat_results):
+      r.set_shape(input_shape)
+      flat_result.append(r)
+
+  results = [
+      nest.pack_sequence_as(structure=input_, flat_sequence=flat_result)
+      for input_, flat_result in zip(input_seq, flat_results)
+  ]
+  return results
+
+
+@deprecation.deprecated(None, "Please use `keras.layers.Bidirectional("
+                        "keras.layers.RNN(cell))`, which is equivalent to "
+                        "this API")
+@tf_export(v1=["nn.bidirectional_dynamic_rnn"])
+def bidirectional_dynamic_rnn(cell_fw,
+                              cell_bw,
+                              inputs,
+                              sequence_length=None,
+                              initial_state_fw=None,
+                              initial_state_bw=None,
+                              dtype=None,
+                              parallel_iterations=None,
+                              swap_memory=False,
+                              time_major=False,
+                              scope=None):
+  """Creates a dynamic version of bidirectional recurrent neural network.
+
+  Takes input and builds independent forward and backward RNNs. The input_size
+  of forward and backward cell must match. The initial state for both directions
+  is zero by default (but can be set optionally) and no intermediate states are
+  ever returned -- the network is fully unrolled for the given (passed in)
+  length(s) of the sequence(s) or completely unrolled if length(s) is not
+  given.
+
+  Args:
+    cell_fw: An instance of RNNCell, to be used for forward direction.
+    cell_bw: An instance of RNNCell, to be used for backward direction.
+    inputs: The RNN inputs.
+      If time_major == False (default), this must be a tensor of shape:
+        `[batch_size, max_time, ...]`, or a nested tuple of such elements.
+      If time_major == True, this must be a tensor of shape: `[max_time,
+        batch_size, ...]`, or a nested tuple of such elements.
+    sequence_length: (optional) An int32/int64 vector, size `[batch_size]`,
+      containing the actual lengths for each of the sequences in the batch. If
+      not provided, all batch entries are assumed to be full sequences; and time
+      reversal is applied from time `0` to `max_time` for each sequence.
+    initial_state_fw: (optional) An initial state for the forward RNN. This must
+      be a tensor of appropriate type and shape `[batch_size,
+      cell_fw.state_size]`. If `cell_fw.state_size` is a tuple, this should be a
+      tuple of tensors having shapes `[batch_size, s] for s in
+      cell_fw.state_size`.
+    initial_state_bw: (optional) Same as for `initial_state_fw`, but using the
+      corresponding properties of `cell_bw`.
+    dtype: (optional) The data type for the initial states and expected output.
+      Required if initial_states are not provided or RNN states have a
+      heterogeneous dtype.
+    parallel_iterations: (Default: 32).  The number of iterations to run in
+      parallel.  Those operations which do not have any temporal dependency and
+      can be run in parallel, will be.  This parameter trades off time for
+      space.  Values >> 1 use more memory but take less time, while smaller
+      values use less memory but computations take longer.
+    swap_memory: Transparently swap the tensors produced in forward inference
+      but needed for back prop from GPU to CPU.  This allows training RNNs which
+      would typically not fit on a single GPU, with very minimal (or no)
+      performance penalty.
+    time_major: The shape format of the `inputs` and `outputs` Tensors. If true,
+      these `Tensors` must be shaped `[max_time, batch_size, depth]`. If false,
+      these `Tensors` must be shaped `[batch_size, max_time, depth]`. Using
+      `time_major = True` is a bit more efficient because it avoids transposes
+      at the beginning and end of the RNN calculation.  However, most TensorFlow
+      data is batch-major, so by default this function accepts input and emits
+      output in batch-major form.
+    scope: VariableScope for the created subgraph; defaults to
+      "bidirectional_rnn"
+
+  Returns:
+    A tuple (outputs, output_states) where:
+      outputs: A tuple (output_fw, output_bw) containing the forward and
+        the backward rnn output `Tensor`.
+        If time_major == False (default),
+          output_fw will be a `Tensor` shaped:
+          `[batch_size, max_time, cell_fw.output_size]`
+          and output_bw will be a `Tensor` shaped:
+          `[batch_size, max_time, cell_bw.output_size]`.
+        If time_major == True,
+          output_fw will be a `Tensor` shaped:
+          `[max_time, batch_size, cell_fw.output_size]`
+          and output_bw will be a `Tensor` shaped:
+          `[max_time, batch_size, cell_bw.output_size]`.
+        It returns a tuple instead of a single concatenated `Tensor`, unlike
+        in the `bidirectional_rnn`. If the concatenated one is preferred,
+        the forward and backward outputs can be concatenated as
+        `tf.concat(outputs, 2)`.
+      output_states: A tuple (output_state_fw, output_state_bw) containing
+        the forward and the backward final states of bidirectional rnn.
+
+  Raises:
+    TypeError: If `cell_fw` or `cell_bw` is not an instance of `RNNCell`.
+  """
+  rnn_cell_impl.assert_like_rnncell("cell_fw", cell_fw)
+  rnn_cell_impl.assert_like_rnncell("cell_bw", cell_bw)
+
+  with vs.variable_scope(scope or "bidirectional_rnn"):
+    # Forward direction
+    with vs.variable_scope("fw") as fw_scope:
+      output_fw, output_state_fw = dynamic_rnn(
+          cell=cell_fw,
+          inputs=inputs,
+          sequence_length=sequence_length,
+          initial_state=initial_state_fw,
+          dtype=dtype,
+          parallel_iterations=parallel_iterations,
+          swap_memory=swap_memory,
+          time_major=time_major,
+          scope=fw_scope)
+
+    # Backward direction
+    if not time_major:
+      time_axis = 1
+      batch_axis = 0
+    else:
+      time_axis = 0
+      batch_axis = 1
+
+    def _reverse(input_, seq_lengths, seq_axis, batch_axis):
+      if seq_lengths is not None:
+        return array_ops.reverse_sequence(
+            input=input_,
+            seq_lengths=seq_lengths,
+            seq_axis=seq_axis,
+            batch_axis=batch_axis)
+      else:
+        return array_ops.reverse(input_, axis=[seq_axis])
+
+    with vs.variable_scope("bw") as bw_scope:
+
+      def _map_reverse(inp):
+        return _reverse(
+            inp,
+            seq_lengths=sequence_length,
+            seq_axis=time_axis,
+            batch_axis=batch_axis)
+
+      inputs_reverse = nest.map_structure(_map_reverse, inputs)
+      tmp, output_state_bw = dynamic_rnn(
+          cell=cell_bw,
+          inputs=inputs_reverse,
+          sequence_length=sequence_length,
+          initial_state=initial_state_bw,
+          dtype=dtype,
+          parallel_iterations=parallel_iterations,
+          swap_memory=swap_memory,
+          time_major=time_major,
+          scope=bw_scope)
+
+  output_bw = _reverse(
+      tmp,
+      seq_lengths=sequence_length,
+      seq_axis=time_axis,
+      batch_axis=batch_axis)
+
+  outputs = (output_fw, output_bw)
+  output_states = (output_state_fw, output_state_bw)
+
+  return (outputs, output_states)
+
+
+@deprecation.deprecated(
+    None,
+    "Please use `keras.layers.RNN(cell)`, which is equivalent to this API")
+@tf_export(v1=["nn.dynamic_rnn"])
+def dynamic_rnn(cell,
+                inputs,
+                sequence_length=None,
+                initial_state=None,
+                dtype=None,
+                parallel_iterations=None,
+                swap_memory=False,
+                time_major=False,
+                scope=None):
+  """Creates a recurrent neural network specified by RNNCell `cell`.
+
+  Performs fully dynamic unrolling of `inputs`.
+
+  Example:
+
+  ```python
+  # create a BasicRNNCell
+  rnn_cell = tf.compat.v1.nn.rnn_cell.BasicRNNCell(hidden_size)
+
+  # 'outputs' is a tensor of shape [batch_size, max_time, cell_state_size]
+
+  # defining initial state
+  initial_state = rnn_cell.zero_state(batch_size, dtype=tf.float32)
+
+  # 'state' is a tensor of shape [batch_size, cell_state_size]
+  outputs, state = tf.compat.v1.nn.dynamic_rnn(rnn_cell, input_data,
+                                     initial_state=initial_state,
+                                     dtype=tf.float32)
+  ```
+
+  ```python
+  # create 2 LSTMCells
+  rnn_layers = [tf.compat.v1.nn.rnn_cell.LSTMCell(size) for size in [128, 256]]
+
+  # create a RNN cell composed sequentially of a number of RNNCells
+  multi_rnn_cell = tf.compat.v1.nn.rnn_cell.MultiRNNCell(rnn_layers)
+
+  # 'outputs' is a tensor of shape [batch_size, max_time, 256]
+  # 'state' is a N-tuple where N is the number of LSTMCells containing a
+  # tf.nn.rnn_cell.LSTMStateTuple for each cell
+  outputs, state = tf.compat.v1.nn.dynamic_rnn(cell=multi_rnn_cell,
+                                     inputs=data,
+                                     dtype=tf.float32)
+  ```
+
+
+  Args:
+    cell: An instance of RNNCell.
+    inputs: The RNN inputs.
+      If `time_major == False` (default), this must be a `Tensor` of shape:
+        `[batch_size, max_time, ...]`, or a nested tuple of such elements.
+      If `time_major == True`, this must be a `Tensor` of shape: `[max_time,
+        batch_size, ...]`, or a nested tuple of such elements. This may also be
+        a (possibly nested) tuple of Tensors satisfying this property.  The
+        first two dimensions must match across all the inputs, but otherwise the
+        ranks and other shape components may differ. In this case, input to
+        `cell` at each time-step will replicate the structure of these tuples,
+        except for the time dimension (from which the time is taken). The input
+        to `cell` at each time step will be a `Tensor` or (possibly nested)
+        tuple of Tensors each with dimensions `[batch_size, ...]`.
+    sequence_length: (optional) An int32/int64 vector sized `[batch_size]`. Used
+      to copy-through state and zero-out outputs when past a batch element's
+      sequence length.  This parameter enables users to extract the last valid
+      state and properly padded outputs, so it is provided for correctness.
+    initial_state: (optional) An initial state for the RNN. If `cell.state_size`
+      is an integer, this must be a `Tensor` of appropriate type and shape
+      `[batch_size, cell.state_size]`. If `cell.state_size` is a tuple, this
+      should be a tuple of tensors having shapes `[batch_size, s] for s in
+      cell.state_size`.
+    dtype: (optional) The data type for the initial state and expected output.
+      Required if initial_state is not provided or RNN state has a heterogeneous
+      dtype.
+    parallel_iterations: (Default: 32).  The number of iterations to run in
+      parallel.  Those operations which do not have any temporal dependency and
+      can be run in parallel, will be.  This parameter trades off time for
+      space.  Values >> 1 use more memory but take less time, while smaller
+      values use less memory but computations take longer.
+    swap_memory: Transparently swap the tensors produced in forward inference
+      but needed for back prop from GPU to CPU.  This allows training RNNs which
+      would typically not fit on a single GPU, with very minimal (or no)
+      performance penalty.
+    time_major: The shape format of the `inputs` and `outputs` Tensors. If true,
+      these `Tensors` must be shaped `[max_time, batch_size, depth]`. If false,
+      these `Tensors` must be shaped `[batch_size, max_time, depth]`. Using
+      `time_major = True` is a bit more efficient because it avoids transposes
+      at the beginning and end of the RNN calculation.  However, most TensorFlow
+      data is batch-major, so by default this function accepts input and emits
+      output in batch-major form.
+    scope: VariableScope for the created subgraph; defaults to "rnn".
+
+  Returns:
+    A pair (outputs, state) where:
+
+    outputs: The RNN output `Tensor`.
+
+      If time_major == False (default), this will be a `Tensor` shaped:
+        `[batch_size, max_time, cell.output_size]`.
+
+      If time_major == True, this will be a `Tensor` shaped:
+        `[max_time, batch_size, cell.output_size]`.
+
+      Note, if `cell.output_size` is a (possibly nested) tuple of integers
+      or `TensorShape` objects, then `outputs` will be a tuple having the
+      same structure as `cell.output_size`, containing Tensors having shapes
+      corresponding to the shape data in `cell.output_size`.
+
+    state: The final state.  If `cell.state_size` is an int, this
+      will be shaped `[batch_size, cell.state_size]`.  If it is a
+      `TensorShape`, this will be shaped `[batch_size] + cell.state_size`.
+      If it is a (possibly nested) tuple of ints or `TensorShape`, this will
+      be a tuple having the corresponding shapes. If cells are `LSTMCells`
+      `state` will be a tuple containing a `LSTMStateTuple` for each cell.
+
+  Raises:
+    TypeError: If `cell` is not an instance of RNNCell.
+    ValueError: If inputs is None or an empty list.
+  """
+  rnn_cell_impl.assert_like_rnncell("cell", cell)
+
+  with vs.variable_scope(scope or "rnn") as varscope:
+    # Create a new scope in which the caching device is either
+    # determined by the parent scope, or is set to place the cached
+    # Variable using the same placement as for the rest of the RNN.
+    if _should_cache():
+      if varscope.caching_device is None:
+        varscope.set_caching_device(lambda op: op.device)
+
+    # By default, time_major==False and inputs are batch-major: shaped
+    #   [batch, time, depth]
+    # For internal calculations, we transpose to [time, batch, depth]
+    flat_input = nest.flatten(inputs)
+
+    if not time_major:
+      # (B,T,D) => (T,B,D)
+      flat_input = [ops.convert_to_tensor(input_) for input_ in flat_input]
+      flat_input = tuple(_transpose_batch_time(input_) for input_ in flat_input)
+
+    parallel_iterations = parallel_iterations or 32
+    if sequence_length is not None:
+      sequence_length = math_ops.cast(sequence_length, dtypes.int32)
+      if sequence_length.get_shape().rank not in (None, 1):
+        raise ValueError(
+            "sequence_length must be a vector of length batch_size, "
+            "but saw shape: %s" % sequence_length.get_shape())
+      sequence_length = array_ops.identity(  # Just to find it in the graph.
+          sequence_length,
+          name="sequence_length")
+
+    batch_size = _best_effort_input_batch_size(flat_input)
+
+    if initial_state is not None:
+      state = initial_state
+    else:
+      if not dtype:
+        raise ValueError("If there is no initial_state, you must give a dtype.")
+      if getattr(cell, "get_initial_state", None) is not None:
+        state = cell.get_initial_state(
+            inputs=None, batch_size=batch_size, dtype=dtype)
+      else:
+        state = cell.zero_state(batch_size, dtype)
+
+    def _assert_has_shape(x, shape):
+      x_shape = array_ops.shape(x)
+      packed_shape = array_ops.stack(shape)
+      return control_flow_ops.Assert(
+          math_ops.reduce_all(math_ops.equal(x_shape, packed_shape)), [
+              "Expected shape for Tensor %s is " % x.name, packed_shape,
+              " but saw shape: ", x_shape
+          ])
+
+    if not context.executing_eagerly() and sequence_length is not None:
+      # Perform some shape validation
+      with ops.control_dependencies(
+          [_assert_has_shape(sequence_length, [batch_size])]):
+        sequence_length = array_ops.identity(
+            sequence_length, name="CheckSeqLen")
+
+    inputs = nest.pack_sequence_as(structure=inputs, flat_sequence=flat_input)
+
+    (outputs, final_state) = _dynamic_rnn_loop(
+        cell,
+        inputs,
+        state,
+        parallel_iterations=parallel_iterations,
+        swap_memory=swap_memory,
+        sequence_length=sequence_length,
+        dtype=dtype)
+
+    # Outputs of _dynamic_rnn_loop are always shaped [time, batch, depth].
+    # If we are performing batch-major calculations, transpose output back
+    # to shape [batch, time, depth]
+    if not time_major:
+      # (T,B,D) => (B,T,D)
+      outputs = nest.map_structure(_transpose_batch_time, outputs)
+
+    return (outputs, final_state)
+
+
+def _dynamic_rnn_loop(cell,
+                      inputs,
+                      initial_state,
+                      parallel_iterations,
+                      swap_memory,
+                      sequence_length=None,
+                      dtype=None):
+  """Internal implementation of Dynamic RNN.
+
+  Args:
+    cell: An instance of RNNCell.
+    inputs: A `Tensor` of shape [time, batch_size, input_size], or a nested
+      tuple of such elements.
+    initial_state: A `Tensor` of shape `[batch_size, state_size]`, or if
+      `cell.state_size` is a tuple, then this should be a tuple of tensors
+      having shapes `[batch_size, s] for s in cell.state_size`.
+    parallel_iterations: Positive Python int.
+    swap_memory: A Python boolean
+    sequence_length: (optional) An `int32` `Tensor` of shape [batch_size].
+    dtype: (optional) Expected dtype of output. If not specified, inferred from
+      initial_state.
+
+  Returns:
+    Tuple `(final_outputs, final_state)`.
+    final_outputs:
+      A `Tensor` of shape `[time, batch_size, cell.output_size]`.  If
+      `cell.output_size` is a (possibly nested) tuple of ints or `TensorShape`
+      objects, then this returns a (possibly nested) tuple of Tensors matching
+      the corresponding shapes.
+    final_state:
+      A `Tensor`, or possibly nested tuple of Tensors, matching in length
+      and shapes to `initial_state`.
+
+  Raises:
+    ValueError: If the input depth cannot be inferred via shape inference
+      from the inputs.
+    ValueError: If time_step is not the same for all the elements in the
+      inputs.
+    ValueError: If batch_size is not the same for all the elements in the
+      inputs.
+  """
+  state = initial_state
+  assert isinstance(parallel_iterations, int), "parallel_iterations must be int"
+
+  state_size = cell.state_size
+
+  flat_input = nest.flatten(inputs)
+  flat_output_size = nest.flatten(cell.output_size)
+
+  # Construct an initial output
+  input_shape = array_ops.shape(flat_input[0])
+  time_steps = input_shape[0]
+  batch_size = _best_effort_input_batch_size(flat_input)
+
+  inputs_got_shape = tuple(
+      input_.get_shape().with_rank_at_least(3) for input_ in flat_input)
+
+  const_time_steps, const_batch_size = inputs_got_shape[0].as_list()[:2]
+
+  for shape in inputs_got_shape:
+    if not shape[2:].is_fully_defined():
+      raise ValueError(
+          "Input size (depth of inputs) must be accessible via shape inference,"
+          " but saw value None.")
+    got_time_steps = shape.dims[0].value
+    got_batch_size = shape.dims[1].value
+    if const_time_steps != got_time_steps:
+      raise ValueError(
+          "Time steps is not the same for all the elements in the input in a "
+          "batch.")
+    if const_batch_size != got_batch_size:
+      raise ValueError(
+          "Batch_size is not the same for all the elements in the input.")
+
+  # Prepare dynamic conditional copying of state & output
+  def _create_zero_arrays(size):
+    size = _concat(batch_size, size)
+    return array_ops.zeros(
+        array_ops.stack(size), _infer_state_dtype(dtype, state))
+
+  flat_zero_output = tuple(
+      _create_zero_arrays(output) for output in flat_output_size)
+  zero_output = nest.pack_sequence_as(
+      structure=cell.output_size, flat_sequence=flat_zero_output)
+
+  if sequence_length is not None:
+    min_sequence_length = math_ops.reduce_min(sequence_length)
+    max_sequence_length = math_ops.reduce_max(sequence_length)
+  else:
+    max_sequence_length = time_steps
+
+  time = array_ops.constant(0, dtype=dtypes.int32, name="time")
+
+  with ops.name_scope("dynamic_rnn") as scope:
+    base_name = scope
+
+  def _create_ta(name, element_shape, dtype):
+    return tensor_array_ops.TensorArray(
+        dtype=dtype,
+        size=time_steps,
+        element_shape=element_shape,
+        tensor_array_name=base_name + name)
+
+  in_graph_mode = not context.executing_eagerly()
+  if in_graph_mode:
+    output_ta = tuple(
+        _create_ta(
+            "output_%d" % i,
+            element_shape=(
+                tensor_shape.TensorShape([const_batch_size]).concatenate(
+                    _maybe_tensor_shape_from_tensor(out_size))),
+            dtype=_infer_state_dtype(dtype, state))
+        for i, out_size in enumerate(flat_output_size))
+    input_ta = tuple(
+        _create_ta(
+            "input_%d" % i,
+            element_shape=flat_input_i.shape[1:],
+            dtype=flat_input_i.dtype)
+        for i, flat_input_i in enumerate(flat_input))
+    input_ta = tuple(
+        ta.unstack(input_) for ta, input_ in zip(input_ta, flat_input))
+  else:
+    output_ta = tuple([0 for _ in range(time_steps.numpy())]
+                      for i in range(len(flat_output_size)))
+    input_ta = flat_input
+
+  def _time_step(time, output_ta_t, state):
+    """Take a time step of the dynamic RNN.
+
+    Args:
+      time: int32 scalar Tensor.
+      output_ta_t: List of `TensorArray`s that represent the output.
+      state: nested tuple of vector tensors that represent the state.
+
+    Returns:
+      The tuple (time + 1, output_ta_t with updated flow, new_state).
+    """
+
+    if in_graph_mode:
+      input_t = tuple(ta.read(time) for ta in input_ta)
+      # Restore some shape information
+      for input_, shape in zip(input_t, inputs_got_shape):
+        input_.set_shape(shape[1:])
+    else:
+      input_t = tuple(ta[time.numpy()] for ta in input_ta)
+
+    input_t = nest.pack_sequence_as(structure=inputs, flat_sequence=input_t)
+    # Keras RNN cells only accept state as list, even if it's a single tensor.
+    is_keras_rnn_cell = _is_keras_rnn_cell(cell)
+    if is_keras_rnn_cell and not nest.is_sequence(state):
+      state = [state]
+    call_cell = lambda: cell(input_t, state)
+
+    if sequence_length is not None:
+      (output, new_state) = _rnn_step(
+          time=time,
+          sequence_length=sequence_length,
+          min_sequence_length=min_sequence_length,
+          max_sequence_length=max_sequence_length,
+          zero_output=zero_output,
+          state=state,
+          call_cell=call_cell,
+          state_size=state_size,
+          skip_conditionals=True)
+    else:
+      (output, new_state) = call_cell()
+
+    # Keras cells always wrap state as list, even if it's a single tensor.
+    if is_keras_rnn_cell and len(new_state) == 1:
+      new_state = new_state[0]
+    # Pack state if using state tuples
+    output = nest.flatten(output)
+
+    if in_graph_mode:
+      output_ta_t = tuple(
+          ta.write(time, out) for ta, out in zip(output_ta_t, output))
+    else:
+      for ta, out in zip(output_ta_t, output):
+        ta[time.numpy()] = out
+
+    return (time + 1, output_ta_t, new_state)
+
+  if in_graph_mode:
+    # Make sure that we run at least 1 step, if necessary, to ensure
+    # the TensorArrays pick up the dynamic shape.
+    loop_bound = math_ops.minimum(time_steps,
+                                  math_ops.maximum(1, max_sequence_length))
+  else:
+    # Using max_sequence_length isn't currently supported in the Eager branch.
+    loop_bound = time_steps
+
+  _, output_final_ta, final_state = control_flow_ops.while_loop(
+      cond=lambda time, *_: time < loop_bound,
+      body=_time_step,
+      loop_vars=(time, output_ta, state),
+      parallel_iterations=parallel_iterations,
+      maximum_iterations=time_steps,
+      swap_memory=swap_memory)
+
+  # Unpack final output if not using output tuples.
+  if in_graph_mode:
+    final_outputs = tuple(ta.stack() for ta in output_final_ta)
+    # Restore some shape information
+    for output, output_size in zip(final_outputs, flat_output_size):
+      shape = _concat([const_time_steps, const_batch_size],
+                      output_size,
+                      static=True)
+      output.set_shape(shape)
+  else:
+    final_outputs = output_final_ta
+
+  final_outputs = nest.pack_sequence_as(
+      structure=cell.output_size, flat_sequence=final_outputs)
+  if not in_graph_mode:
+    final_outputs = nest.map_structure_up_to(
+        cell.output_size, lambda x: array_ops.stack(x, axis=0), final_outputs)
+
+  return (final_outputs, final_state)
+
+
+@tf_export(v1=["nn.raw_rnn"])
+def raw_rnn(cell,
+            loop_fn,
+            parallel_iterations=None,
+            swap_memory=False,
+            scope=None):
+  """Creates an `RNN` specified by RNNCell `cell` and loop function `loop_fn`.
+
+  **NOTE: This method is still in testing, and the API may change.**
+
+  This function is a more primitive version of `dynamic_rnn` that provides
+  more direct access to the inputs each iteration.  It also provides more
+  control over when to start and finish reading the sequence, and
+  what to emit for the output.
+
+  For example, it can be used to implement the dynamic decoder of a seq2seq
+  model.
+
+  Instead of working with `Tensor` objects, most operations work with
+  `TensorArray` objects directly.
+
+  The operation of `raw_rnn`, in pseudo-code, is basically the following:
+
+  ```python
+  time = tf.constant(0, dtype=tf.int32)
+  (finished, next_input, initial_state, emit_structure, loop_state) = loop_fn(
+      time=time, cell_output=None, cell_state=None, loop_state=None)
+  emit_ta = TensorArray(dynamic_size=True, dtype=initial_state.dtype)
+  state = initial_state
+  while not all(finished):
+    (output, cell_state) = cell(next_input, state)
+    (next_finished, next_input, next_state, emit, loop_state) = loop_fn(
+        time=time + 1, cell_output=output, cell_state=cell_state,
+        loop_state=loop_state)
+    # Emit zeros and copy forward state for minibatch entries that are finished.
+    state = tf.where(finished, state, next_state)
+    emit = tf.where(finished, tf.zeros_like(emit_structure), emit)
+    emit_ta = emit_ta.write(time, emit)
+    # If any new minibatch entries are marked as finished, mark these.
+    finished = tf.logical_or(finished, next_finished)
+    time += 1
+  return (emit_ta, state, loop_state)
+  ```
+
+  with the additional properties that output and state may be (possibly nested)
+  tuples, as determined by `cell.output_size` and `cell.state_size`, and
+  as a result the final `state` and `emit_ta` may themselves be tuples.
+
+  A simple implementation of `dynamic_rnn` via `raw_rnn` looks like this:
+
+  ```python
+  inputs = tf.compat.v1.placeholder(shape=(max_time, batch_size, input_depth),
+                          dtype=tf.float32)
+  sequence_length = tf.compat.v1.placeholder(shape=(batch_size,),
+  dtype=tf.int32)
+  inputs_ta = tf.TensorArray(dtype=tf.float32, size=max_time)
+  inputs_ta = inputs_ta.unstack(inputs)
+
+  cell = tf.compat.v1.nn.rnn_cell.LSTMCell(num_units)
+
+  def loop_fn(time, cell_output, cell_state, loop_state):
+    emit_output = cell_output  # == None for time == 0
+    if cell_output is None:  # time == 0
+      next_cell_state = cell.zero_state(batch_size, tf.float32)
+    else:
+      next_cell_state = cell_state
+    elements_finished = (time >= sequence_length)
+    finished = tf.reduce_all(elements_finished)
+    next_input = tf.cond(
+        finished,
+        lambda: tf.zeros([batch_size, input_depth], dtype=tf.float32),
+        lambda: inputs_ta.read(time))
+    next_loop_state = None
+    return (elements_finished, next_input, next_cell_state,
+            emit_output, next_loop_state)
+
+  outputs_ta, final_state, _ = raw_rnn(cell, loop_fn)
+  outputs = outputs_ta.stack()
+  ```
+
+  Args:
+    cell: An instance of RNNCell.
+    loop_fn: A callable that takes inputs `(time, cell_output, cell_state,
+      loop_state)` and returns the tuple `(finished, next_input,
+      next_cell_state, emit_output, next_loop_state)`. Here `time` is an int32
+      scalar `Tensor`, `cell_output` is a `Tensor` or (possibly nested) tuple of
+      tensors as determined by `cell.output_size`, and `cell_state` is a
+      `Tensor` or (possibly nested) tuple of tensors, as determined by the
+      `loop_fn` on its first call (and should match `cell.state_size`).
+      The outputs are: `finished`, a boolean `Tensor` of
+      shape `[batch_size]`, `next_input`: the next input to feed to `cell`,
+      `next_cell_state`: the next state to feed to `cell`,
+      and `emit_output`: the output to store for this iteration.  Note that
+        `emit_output` should be a `Tensor` or (possibly nested) tuple of tensors
+        which is aggregated in the `emit_ta` inside the `while_loop`. For the
+        first call to `loop_fn`, the `emit_output` corresponds to the
+        `emit_structure` which is then used to determine the size of the
+        `zero_tensor` for the `emit_ta` (defaults to `cell.output_size`). For
+        the subsequent calls to the `loop_fn`, the `emit_output` corresponds to
+        the actual output tensor that is to be aggregated in the `emit_ta`. The
+        parameter `cell_state` and output `next_cell_state` may be either a
+        single or (possibly nested) tuple of tensors.  The parameter
+        `loop_state` and output `next_loop_state` may be either a single or
+        (possibly nested) tuple of `Tensor` and `TensorArray` objects.  This
+        last parameter may be ignored by `loop_fn` and the return value may be
+        `None`.  If it is not `None`, then the `loop_state` will be propagated
+        through the RNN loop, for use purely by `loop_fn` to keep track of its
+        own state. The `next_loop_state` parameter returned may be `None`.  The
+        first call to `loop_fn` will be `time = 0`, `cell_output = None`,
+      `cell_state = None`, and `loop_state = None`.  For this call: The
+        `next_cell_state` value should be the value with which to initialize the
+        cell's state.  It may be a final state from a previous RNN or it may be
+        the output of `cell.zero_state()`.  It should be a (possibly nested)
+        tuple structure of tensors. If `cell.state_size` is an integer, this
+        must be a `Tensor` of appropriate type and shape `[batch_size,
+        cell.state_size]`. If `cell.state_size` is a `TensorShape`, this must be
+        a `Tensor` of appropriate type and shape `[batch_size] +
+        cell.state_size`. If `cell.state_size` is a (possibly nested) tuple of
+        ints or `TensorShape`, this will be a tuple having the corresponding
+        shapes. The `emit_output` value may be either `None` or a (possibly
+        nested) tuple structure of tensors, e.g., `(tf.zeros(shape_0,
+        dtype=dtype_0), tf.zeros(shape_1, dtype=dtype_1))`. If this first
+        `emit_output` return value is `None`, then the `emit_ta` result of
+        `raw_rnn` will have the same structure and dtypes as `cell.output_size`.
+        Otherwise `emit_ta` will have the same structure, shapes (prepended with
+        a `batch_size` dimension), and dtypes as `emit_output`.  The actual
+        values returned for `emit_output` at this initializing call are ignored.
+        Note, this emit structure must be consistent across all time steps.
+    parallel_iterations: (Default: 32).  The number of iterations to run in
+      parallel.  Those operations which do not have any temporal dependency and
+      can be run in parallel, will be.  This parameter trades off time for
+      space.  Values >> 1 use more memory but take less time, while smaller
+      values use less memory but computations take longer.
+    swap_memory: Transparently swap the tensors produced in forward inference
+      but needed for back prop from GPU to CPU.  This allows training RNNs which
+      would typically not fit on a single GPU, with very minimal (or no)
+      performance penalty.
+    scope: VariableScope for the created subgraph; defaults to "rnn".
+
+  Returns:
+    A tuple `(emit_ta, final_state, final_loop_state)` where:
+
+    `emit_ta`: The RNN output `TensorArray`.
+       If `loop_fn` returns a (possibly nested) set of Tensors for
+       `emit_output` during initialization, (inputs `time = 0`,
+       `cell_output = None`, and `loop_state = None`), then `emit_ta` will
+       have the same structure, dtypes, and shapes as `emit_output` instead.
+       If `loop_fn` returns `emit_output = None` during this call,
+       the structure of `cell.output_size` is used:
+       If `cell.output_size` is a (possibly nested) tuple of integers
+       or `TensorShape` objects, then `emit_ta` will be a tuple having the
+       same structure as `cell.output_size`, containing TensorArrays whose
+       elements' shapes correspond to the shape data in `cell.output_size`.
+
+    `final_state`: The final cell state.  If `cell.state_size` is an int, this
+      will be shaped `[batch_size, cell.state_size]`.  If it is a
+      `TensorShape`, this will be shaped `[batch_size] + cell.state_size`.
+      If it is a (possibly nested) tuple of ints or `TensorShape`, this will
+      be a tuple having the corresponding shapes.
+
+    `final_loop_state`: The final loop state as returned by `loop_fn`.
+
+  Raises:
+    TypeError: If `cell` is not an instance of RNNCell, or `loop_fn` is not
+      a `callable`.
+  """
+  rnn_cell_impl.assert_like_rnncell("cell", cell)
+
+  if not callable(loop_fn):
+    raise TypeError("loop_fn must be a callable")
+
+  parallel_iterations = parallel_iterations or 32
+
+  # Create a new scope in which the caching device is either
+  # determined by the parent scope, or is set to place the cached
+  # Variable using the same placement as for the rest of the RNN.
+  with vs.variable_scope(scope or "rnn") as varscope:
+    if _should_cache():
+      if varscope.caching_device is None:
+        varscope.set_caching_device(lambda op: op.device)
+
+    time = constant_op.constant(0, dtype=dtypes.int32)
+    (elements_finished, next_input,
+     initial_state, emit_structure, init_loop_state) = loop_fn(
+         time, None, None, None)  # time, cell_output, cell_state, loop_state
+    flat_input = nest.flatten(next_input)
+
+    # Need a surrogate loop state for the while_loop if none is available.
+    loop_state = (
+        init_loop_state if init_loop_state is not None else
+        constant_op.constant(0, dtype=dtypes.int32))
+
+    input_shape = [input_.get_shape() for input_ in flat_input]
+    static_batch_size = tensor_shape.dimension_at_index(input_shape[0], 0)
+
+    for input_shape_i in input_shape:
+      # Static verification that batch sizes all match
+      static_batch_size.merge_with(
+          tensor_shape.dimension_at_index(input_shape_i, 0))
+
+    batch_size = tensor_shape.dimension_value(static_batch_size)
+    const_batch_size = batch_size
+    if batch_size is None:
+      batch_size = array_ops.shape(flat_input[0])[0]
+
+    nest.assert_same_structure(initial_state, cell.state_size)
+    state = initial_state
+    flat_state = nest.flatten(state)
+    flat_state = [ops.convert_to_tensor(s) for s in flat_state]
+    state = nest.pack_sequence_as(structure=state, flat_sequence=flat_state)
+
+    if emit_structure is not None:
+      flat_emit_structure = nest.flatten(emit_structure)
+      flat_emit_size = [
+          emit.shape if emit.shape.is_fully_defined() else array_ops.shape(emit)
+          for emit in flat_emit_structure
+      ]
+      flat_emit_dtypes = [emit.dtype for emit in flat_emit_structure]
+    else:
+      emit_structure = cell.output_size
+      flat_emit_size = nest.flatten(emit_structure)
+      flat_emit_dtypes = [flat_state[0].dtype] * len(flat_emit_size)
+
+    flat_emit_ta = [
+        tensor_array_ops.TensorArray(
+            dtype=dtype_i,
+            dynamic_size=True,
+            element_shape=(tensor_shape.TensorShape([
+                const_batch_size
+            ]).concatenate(_maybe_tensor_shape_from_tensor(size_i))),
+            size=0,
+            name="rnn_output_%d" % i)
+        for i, (dtype_i,
+                size_i) in enumerate(zip(flat_emit_dtypes, flat_emit_size))
+    ]
+    emit_ta = nest.pack_sequence_as(
+        structure=emit_structure, flat_sequence=flat_emit_ta)
+    flat_zero_emit = [
+        array_ops.zeros(_concat(batch_size, size_i), dtype_i)
+        for size_i, dtype_i in zip(flat_emit_size, flat_emit_dtypes)
+    ]
+    zero_emit = nest.pack_sequence_as(
+        structure=emit_structure, flat_sequence=flat_zero_emit)
+
+    def condition(unused_time, elements_finished, *_):
+      return math_ops.logical_not(math_ops.reduce_all(elements_finished))
+
+    def body(time, elements_finished, current_input, emit_ta, state,
+             loop_state):
+      """Internal while loop body for raw_rnn.
+
+      Args:
+        time: time scalar.
+        elements_finished: batch-size vector.
+        current_input: possibly nested tuple of input tensors.
+        emit_ta: possibly nested tuple of output TensorArrays.
+        state: possibly nested tuple of state tensors.
+        loop_state: possibly nested tuple of loop state tensors.
+
+      Returns:
+        Tuple having the same size as Args but with updated values.
+      """
+      (next_output, cell_state) = cell(current_input, state)
+
+      nest.assert_same_structure(state, cell_state)
+      nest.assert_same_structure(cell.output_size, next_output)
+
+      next_time = time + 1
+      (next_finished, next_input, next_state, emit_output,
+       next_loop_state) = loop_fn(next_time, next_output, cell_state,
+                                  loop_state)
+
+      nest.assert_same_structure(state, next_state)
+      nest.assert_same_structure(current_input, next_input)
+      nest.assert_same_structure(emit_ta, emit_output)
+
+      # If loop_fn returns None for next_loop_state, just reuse the
+      # previous one.
+      loop_state = loop_state if next_loop_state is None else next_loop_state
+
+      def _copy_some_through(current, candidate):
+        """Copy some tensors through via array_ops.where."""
+
+        def copy_fn(cur_i, cand_i):
+          # TensorArray and scalar get passed through.
+          if isinstance(cur_i, tensor_array_ops.TensorArray):
+            return cand_i
+          if cur_i.shape.rank == 0:
+            return cand_i
+          # Otherwise propagate the old or the new value.
+          with ops.colocate_with(cand_i):
+            return array_ops.where(elements_finished, cur_i, cand_i)
+
+        return nest.map_structure(copy_fn, current, candidate)
+
+      emit_output = _copy_some_through(zero_emit, emit_output)
+      next_state = _copy_some_through(state, next_state)
+
+      emit_ta = nest.map_structure(lambda ta, emit: ta.write(time, emit),
+                                   emit_ta, emit_output)
+
+      elements_finished = math_ops.logical_or(elements_finished, next_finished)
+
+      return (next_time, elements_finished, next_input, emit_ta, next_state,
+              loop_state)
+
+    returned = control_flow_ops.while_loop(
+        condition,
+        body,
+        loop_vars=[
+            time, elements_finished, next_input, emit_ta, state, loop_state
+        ],
+        parallel_iterations=parallel_iterations,
+        swap_memory=swap_memory)
+
+    (emit_ta, final_state, final_loop_state) = returned[-3:]
+
+    if init_loop_state is None:
+      final_loop_state = None
+
+    return (emit_ta, final_state, final_loop_state)
+
+
+@deprecation.deprecated(None,
+                        "Please use `keras.layers.RNN(cell, unroll=True)`, "
+                        "which is equivalent to this API")
+@tf_export(v1=["nn.static_rnn"])
+def static_rnn(cell,
+               inputs,
+               initial_state=None,
+               dtype=None,
+               sequence_length=None,
+               scope=None):
+  """Creates a recurrent neural network specified by RNNCell `cell`.
+
+  The simplest form of RNN network generated is:
+
+  ```python
+    state = cell.zero_state(...)
+    outputs = []
+    for input_ in inputs:
+      output, state = cell(input_, state)
+      outputs.append(output)
+    return (outputs, state)
+  ```
+  However, a few other options are available:
+
+  An initial state can be provided.
+  If the sequence_length vector is provided, dynamic calculation is performed.
+  This method of calculation does not compute the RNN steps past the maximum
+  sequence length of the minibatch (thus saving computational time),
+  and properly propagates the state at an example's sequence length
+  to the final state output.
+
+  The dynamic calculation performed is, at time `t` for batch row `b`,
+
+  ```python
+    (output, state)(b, t) =
+      (t >= sequence_length(b))
+        ? (zeros(cell.output_size), states(b, sequence_length(b) - 1))
+        : cell(input(b, t), state(b, t - 1))
+  ```
+
+  Args:
+    cell: An instance of RNNCell.
+    inputs: A length T list of inputs, each a `Tensor` of shape `[batch_size,
+      input_size]`, or a nested tuple of such elements.
+    initial_state: (optional) An initial state for the RNN. If `cell.state_size`
+      is an integer, this must be a `Tensor` of appropriate type and shape
+      `[batch_size, cell.state_size]`. If `cell.state_size` is a tuple, this
+      should be a tuple of tensors having shapes `[batch_size, s] for s in
+      cell.state_size`.
+    dtype: (optional) The data type for the initial state and expected output.
+      Required if initial_state is not provided or RNN state has a heterogeneous
+      dtype.
+    sequence_length: Specifies the length of each sequence in inputs. An int32
+      or int64 vector (tensor) size `[batch_size]`, values in `[0, T)`.
+    scope: VariableScope for the created subgraph; defaults to "rnn".
+
+  Returns:
+    A pair (outputs, state) where:
+
+    - outputs is a length T list of outputs (one for each input), or a nested
+      tuple of such elements.
+    - state is the final state
+
+  Raises:
+    TypeError: If `cell` is not an instance of RNNCell.
+    ValueError: If `inputs` is `None` or an empty list, or if the input depth
+      (column size) cannot be inferred from inputs via shape inference.
+  """
+  rnn_cell_impl.assert_like_rnncell("cell", cell)
+  if not nest.is_sequence(inputs):
+    raise TypeError("inputs must be a sequence")
+  if not inputs:
+    raise ValueError("inputs must not be empty")
+
+  outputs = []
+  # Create a new scope in which the caching device is either
+  # determined by the parent scope, or is set to place the cached
+  # Variable using the same placement as for the rest of the RNN.
+  with vs.variable_scope(scope or "rnn") as varscope:
+    if _should_cache():
+      if varscope.caching_device is None:
+        varscope.set_caching_device(lambda op: op.device)
+
+    # Obtain the first sequence of the input
+    first_input = inputs
+    while nest.is_sequence(first_input):
+      first_input = first_input[0]
+
+    # Temporarily avoid EmbeddingWrapper and seq2seq badness
+    # TODO(lukaszkaiser): remove EmbeddingWrapper
+    if first_input.get_shape().rank != 1:
+
+      input_shape = first_input.get_shape().with_rank_at_least(2)
+      fixed_batch_size = input_shape.dims[0]
+
+      flat_inputs = nest.flatten(inputs)
+      for flat_input in flat_inputs:
+        input_shape = flat_input.get_shape().with_rank_at_least(2)
+        batch_size, input_size = tensor_shape.dimension_at_index(
+            input_shape, 0), input_shape[1:]
+        fixed_batch_size.merge_with(batch_size)
+        for i, size in enumerate(input_size.dims):
+          if tensor_shape.dimension_value(size) is None:
+            raise ValueError(
+                "Input size (dimension %d of inputs) must be accessible via "
+                "shape inference, but saw value None." % i)
+    else:
+      fixed_batch_size = first_input.get_shape().with_rank_at_least(1)[0]
+
+    if tensor_shape.dimension_value(fixed_batch_size):
+      batch_size = tensor_shape.dimension_value(fixed_batch_size)
+    else:
+      batch_size = array_ops.shape(first_input)[0]
+    if initial_state is not None:
+      state = initial_state
+    else:
+      if not dtype:
+        raise ValueError("If no initial_state is provided, "
+                         "dtype must be specified")
+      if getattr(cell, "get_initial_state", None) is not None:
+        state = cell.get_initial_state(
+            inputs=None, batch_size=batch_size, dtype=dtype)
+      else:
+        state = cell.zero_state(batch_size, dtype)
+
+    if sequence_length is not None:  # Prepare variables
+      sequence_length = ops.convert_to_tensor(
+          sequence_length, name="sequence_length")
+      if sequence_length.get_shape().rank not in (None, 1):
+        raise ValueError(
+            "sequence_length must be a vector of length batch_size")
+
+      def _create_zero_output(output_size):
+        # convert int to TensorShape if necessary
+        size = _concat(batch_size, output_size)
+        output = array_ops.zeros(
+            array_ops.stack(size), _infer_state_dtype(dtype, state))
+        shape = _concat(
+            tensor_shape.dimension_value(fixed_batch_size),
+            output_size,
+            static=True)
+        output.set_shape(tensor_shape.TensorShape(shape))
+        return output
+
+      output_size = cell.output_size
+      flat_output_size = nest.flatten(output_size)
+      flat_zero_output = tuple(
+          _create_zero_output(size) for size in flat_output_size)
+      zero_output = nest.pack_sequence_as(
+          structure=output_size, flat_sequence=flat_zero_output)
+
+      sequence_length = math_ops.cast(sequence_length, dtypes.int32)
+      min_sequence_length = math_ops.reduce_min(sequence_length)
+      max_sequence_length = math_ops.reduce_max(sequence_length)
+
+    # Keras RNN cells only accept state as list, even if it's a single tensor.
+    is_keras_rnn_cell = _is_keras_rnn_cell(cell)
+    if is_keras_rnn_cell and not nest.is_sequence(state):
+      state = [state]
+    for time, input_ in enumerate(inputs):
+      if time > 0:
+        varscope.reuse_variables()
+      # pylint: disable=cell-var-from-loop
+      call_cell = lambda: cell(input_, state)
+      # pylint: enable=cell-var-from-loop
+      if sequence_length is not None:
+        (output, state) = _rnn_step(
+            time=time,
+            sequence_length=sequence_length,
+            min_sequence_length=min_sequence_length,
+            max_sequence_length=max_sequence_length,
+            zero_output=zero_output,
+            state=state,
+            call_cell=call_cell,
+            state_size=cell.state_size)
+      else:
+        (output, state) = call_cell()
+      outputs.append(output)
+    # Keras RNN cells only return state as list, even if it's a single tensor.
+    if is_keras_rnn_cell and len(state) == 1:
+      state = state[0]
+
+    return (outputs, state)
+
+
+@deprecation.deprecated(None,
+                        "Please use `keras.layers.RNN(cell, stateful=True)`, "
+                        "which is equivalent to this API")
+@tf_export(v1=["nn.static_state_saving_rnn"])
+def static_state_saving_rnn(cell,
+                            inputs,
+                            state_saver,
+                            state_name,
+                            sequence_length=None,
+                            scope=None):
+  """RNN that accepts a state saver for time-truncated RNN calculation.
+
+  Args:
+    cell: An instance of `RNNCell`.
+    inputs: A length T list of inputs, each a `Tensor` of shape `[batch_size,
+      input_size]`.
+    state_saver: A state saver object with methods `state` and `save_state`.
+    state_name: Python string or tuple of strings.  The name to use with the
+      state_saver. If the cell returns tuples of states (i.e., `cell.state_size`
+      is a tuple) then `state_name` should be a tuple of strings having the same
+      length as `cell.state_size`.  Otherwise it should be a single string.
+    sequence_length: (optional) An int32/int64 vector size [batch_size]. See the
+      documentation for rnn() for more details about sequence_length.
+    scope: VariableScope for the created subgraph; defaults to "rnn".
+
+  Returns:
+    A pair (outputs, state) where:
+      outputs is a length T list of outputs (one for each input)
+      states is the final state
+
+  Raises:
+    TypeError: If `cell` is not an instance of RNNCell.
+    ValueError: If `inputs` is `None` or an empty list, or if the arity and
+     type of `state_name` does not match that of `cell.state_size`.
+  """
+  state_size = cell.state_size
+  state_is_tuple = nest.is_sequence(state_size)
+  state_name_tuple = nest.is_sequence(state_name)
+
+  if state_is_tuple != state_name_tuple:
+    raise ValueError("state_name should be the same type as cell.state_size.  "
+                     "state_name: %s, cell.state_size: %s" %
+                     (str(state_name), str(state_size)))
+
+  if state_is_tuple:
+    state_name_flat = nest.flatten(state_name)
+    state_size_flat = nest.flatten(state_size)
+
+    if len(state_name_flat) != len(state_size_flat):
+      raise ValueError("#elems(state_name) != #elems(state_size): %d vs. %d" %
+                       (len(state_name_flat), len(state_size_flat)))
+
+    initial_state = nest.pack_sequence_as(
+        structure=state_size,
+        flat_sequence=[state_saver.state(s) for s in state_name_flat])
+  else:
+    initial_state = state_saver.state(state_name)
+
+  (outputs, state) = static_rnn(
+      cell,
+      inputs,
+      initial_state=initial_state,
+      sequence_length=sequence_length,
+      scope=scope)
+
+  if state_is_tuple:
+    flat_state = nest.flatten(state)
+    state_name = nest.flatten(state_name)
+    save_state = [
+        state_saver.save_state(name, substate)
+        for name, substate in zip(state_name, flat_state)
+    ]
+  else:
+    save_state = [state_saver.save_state(state_name, state)]
+
+  with ops.control_dependencies(save_state):
+    last_output = outputs[-1]
+    flat_last_output = nest.flatten(last_output)
+    flat_last_output = [
+        array_ops.identity(output) for output in flat_last_output
+    ]
+    outputs[-1] = nest.pack_sequence_as(
+        structure=last_output, flat_sequence=flat_last_output)
+
+    if state_is_tuple:
+      state = nest.pack_sequence_as(
+          structure=state,
+          flat_sequence=[array_ops.identity(s) for s in flat_state])
+    else:
+      state = array_ops.identity(state)
+
+  return (outputs, state)
+
+
+@deprecation.deprecated(None, "Please use `keras.layers.Bidirectional("
+                        "keras.layers.RNN(cell, unroll=True))`, which is "
+                        "equivalent to this API")
+@tf_export(v1=["nn.static_bidirectional_rnn"])
+def static_bidirectional_rnn(cell_fw,
+                             cell_bw,
+                             inputs,
+                             initial_state_fw=None,
+                             initial_state_bw=None,
+                             dtype=None,
+                             sequence_length=None,
+                             scope=None):
+  """Creates a bidirectional recurrent neural network.
+
+  Similar to the unidirectional case above (rnn) but takes input and builds
+  independent forward and backward RNNs with the final forward and backward
+  outputs depth-concatenated, such that the output will have the format
+  [time][batch][cell_fw.output_size + cell_bw.output_size]. The input_size of
+  forward and backward cell must match. The initial state for both directions
+  is zero by default (but can be set optionally) and no intermediate states are
+  ever returned -- the network is fully unrolled for the given (passed in)
+  length(s) of the sequence(s) or completely unrolled if length(s) is not given.
+
+  Args:
+    cell_fw: An instance of RNNCell, to be used for forward direction.
+    cell_bw: An instance of RNNCell, to be used for backward direction.
+    inputs: A length T list of inputs, each a tensor of shape [batch_size,
+      input_size], or a nested tuple of such elements.
+    initial_state_fw: (optional) An initial state for the forward RNN. This must
+      be a tensor of appropriate type and shape `[batch_size,
+      cell_fw.state_size]`. If `cell_fw.state_size` is a tuple, this should be a
+      tuple of tensors having shapes `[batch_size, s] for s in
+      cell_fw.state_size`.
+    initial_state_bw: (optional) Same as for `initial_state_fw`, but using the
+      corresponding properties of `cell_bw`.
+    dtype: (optional) The data type for the initial state.  Required if either
+      of the initial states are not provided.
+    sequence_length: (optional) An int32/int64 vector, size `[batch_size]`,
+      containing the actual lengths for each of the sequences.
+    scope: VariableScope for the created subgraph; defaults to
+      "bidirectional_rnn"
+
+  Returns:
+    A tuple (outputs, output_state_fw, output_state_bw) where:
+      outputs is a length `T` list of outputs (one for each input), which
+        are depth-concatenated forward and backward outputs.
+      output_state_fw is the final state of the forward rnn.
+      output_state_bw is the final state of the backward rnn.
+
+  Raises:
+    TypeError: If `cell_fw` or `cell_bw` is not an instance of `RNNCell`.
+    ValueError: If inputs is None or an empty list.
+  """
+  rnn_cell_impl.assert_like_rnncell("cell_fw", cell_fw)
+  rnn_cell_impl.assert_like_rnncell("cell_bw", cell_bw)
+  if not nest.is_sequence(inputs):
+    raise TypeError("inputs must be a sequence")
+  if not inputs:
+    raise ValueError("inputs must not be empty")
+
+  with vs.variable_scope(scope or "bidirectional_rnn"):
+    # Forward direction
+    with vs.variable_scope("fw") as fw_scope:
+      output_fw, output_state_fw = static_rnn(
+          cell_fw,
+          inputs,
+          initial_state_fw,
+          dtype,
+          sequence_length,
+          scope=fw_scope)
+
+    # Backward direction
+    with vs.variable_scope("bw") as bw_scope:
+      reversed_inputs = _reverse_seq(inputs, sequence_length)
+      tmp, output_state_bw = static_rnn(
+          cell_bw,
+          reversed_inputs,
+          initial_state_bw,
+          dtype,
+          sequence_length,
+          scope=bw_scope)
+
+  output_bw = _reverse_seq(tmp, sequence_length)
+  # Concat each of the forward/backward outputs
+  flat_output_fw = nest.flatten(output_fw)
+  flat_output_bw = nest.flatten(output_bw)
+
+  flat_outputs = tuple(
+      array_ops.concat([fw, bw], 1)
+      for fw, bw in zip(flat_output_fw, flat_output_bw))
+
+  outputs = nest.pack_sequence_as(
+      structure=output_fw, flat_sequence=flat_outputs)
+
+  return (outputs, output_state_fw, output_state_bw)

--- a/src/test.py
+++ b/src/test.py
@@ -21,32 +21,32 @@ import pipeline
 import filters
 import model_fn
 
-FLAGS = tf.app.flags.FLAGS
+FLAGS = tf.compat.v1.app.flags.FLAGS
 
-tf.app.flags.DEFINE_string( 'model','../data/model',
+tf.compat.v1.app.flags.DEFINE_string( 'model','../data/model',
                             """Directory for model checkpoints""" )
-tf.app.flags.DEFINE_string( 'lexicon',None,
+tf.compat.v1.app.flags.DEFINE_string( 'lexicon',None,
 			    """File containing lexicon of image words""" )
-tf.app.flags.DEFINE_float( 'lexicon_prior',None,
+tf.compat.v1.app.flags.DEFINE_float( 'lexicon_prior',None,
 			    """Prior bias [0,1] for lexicon word""" )
 
-tf.app.flags.DEFINE_integer( 'batch_size',2**9,
+tf.compat.v1.app.flags.DEFINE_integer( 'batch_size',2**9,
                              """Eval batch size""" )
 
-tf.app.flags.DEFINE_string( 'test_path','../data/',
+tf.compat.v1.app.flags.DEFINE_string( 'test_path','../data/',
                             """Base directory for test/validation data""" )
-tf.app.flags.DEFINE_string( 'filename_pattern','test/words-*',
+tf.compat.v1.app.flags.DEFINE_string( 'filename_pattern','test/words-*',
                             """File pattern for test input data""" )
-tf.app.flags.DEFINE_integer( 'num_input_threads',4,
+tf.compat.v1.app.flags.DEFINE_integer( 'num_input_threads',4,
                              """Number of readers for input data""" )
 
-tf.app.flags.DEFINE_integer('min_image_width',None,
+tf.compat.v1.app.flags.DEFINE_integer('min_image_width',None,
                             """Minimum allowable input image width""")
-tf.app.flags.DEFINE_integer('max_image_width',None,
+tf.compat.v1.app.flags.DEFINE_integer('max_image_width',None,
                             """Maximum allowable input image width""")
-tf.app.flags.DEFINE_integer('min_string_length',None,
+tf.compat.v1.app.flags.DEFINE_integer('min_string_length',None,
                             """Minimum allowable input string length""")
-tf.app.flags.DEFINE_integer('max_string_length',None,
+tf.compat.v1.app.flags.DEFINE_integer('max_string_length',None,
                             """Maximum allowable input string_length""")
 
 

--- a/src/test.py
+++ b/src/test.py
@@ -83,7 +83,7 @@ def _get_input():
 def _get_config():
     """Setup config to soften device placement"""
 
-    device_config=tf.ConfigProto(
+    device_config=tf.compat.v1.ConfigProto(
         allow_soft_placement=True, 
         log_device_placement=False )
 
@@ -106,4 +106,4 @@ def main(argv=None):
     print(evaluations)
 
 if __name__ == '__main__':
-    tf.app.run()
+    tf.compat.v1.app.run()

--- a/src/train.py
+++ b/src/train.py
@@ -23,64 +23,64 @@ import charset
 import model_fn
 import filters
 
-FLAGS = tf.app.flags.FLAGS
+FLAGS = tf.compat.v1.app.flags.FLAGS
 
-tf.app.flags.DEFINE_string('output','../data/model',
+tf.compat.v1.app.flags.DEFINE_string('output','../data/model',
                           """Directory for event logs and checkpoints""")
-tf.app.flags.DEFINE_string('tune_from','',
+tf.compat.v1.app.flags.DEFINE_string('tune_from','',
                           """Path to pre-trained model checkpoint""")
-tf.app.flags.DEFINE_string('tune_scope','',
+tf.compat.v1.app.flags.DEFINE_string('tune_scope','',
                           """Variable scope for training""")
 
-tf.app.flags.DEFINE_integer('batch_size',2**5,
+tf.compat.v1.app.flags.DEFINE_integer('batch_size',2**5,
                             """Mini-batch size""")
-tf.app.flags.DEFINE_float('learning_rate',1e-4,
+tf.compat.v1.app.flags.DEFINE_float('learning_rate',1e-4,
                           """Initial learning rate""")
-tf.app.flags.DEFINE_float('momentum',0.9,
+tf.compat.v1.app.flags.DEFINE_float('momentum',0.9,
                           """Optimizer gradient first-order momentum""")
-tf.app.flags.DEFINE_float('decay_rate',0.9,
+tf.compat.v1.app.flags.DEFINE_float('decay_rate',0.9,
                           """Learning rate decay base""")
-tf.app.flags.DEFINE_float('decay_steps',2**16,
+tf.compat.v1.app.flags.DEFINE_float('decay_steps',2**16,
                           """Learning rate decay exponent scale""")
-tf.app.flags.DEFINE_boolean('decay_staircase',False,
+tf.compat.v1.app.flags.DEFINE_boolean('decay_staircase',False,
                           """Staircase learning rate decay by integer division""")
-tf.app.flags.DEFINE_integer('max_num_steps', 2**21,
+tf.compat.v1.app.flags.DEFINE_integer('max_num_steps', 2**21,
                             """Number of optimization steps to run""")
-tf.app.flags.DEFINE_integer('save_checkpoint_secs', 120,
+tf.compat.v1.app.flags.DEFINE_integer('save_checkpoint_secs', 120,
                             """Interval between daving checkpoints""")
 
-tf.app.flags.DEFINE_integer('num_input_threads',4,
+tf.compat.v1.app.flags.DEFINE_integer('num_input_threads',4,
                           """Number of readers/generators for input data""")
-tf.app.flags.DEFINE_integer('num_gpus', 1,
+tf.compat.v1.app.flags.DEFINE_integer('num_gpus', 1,
                             """Number of GPUs to use for distributed training""")
-tf.app.flags.DEFINE_boolean('bucket_data',True,
+tf.compat.v1.app.flags.DEFINE_boolean('bucket_data',True,
                             """Bucket training data by width for efficiency""")
 
-tf.app.flags.DEFINE_integer('min_image_width',None,
+tf.compat.v1.app.flags.DEFINE_integer('min_image_width',None,
                             """Minimum allowable input image width""")
-tf.app.flags.DEFINE_integer('max_image_width',None,
+tf.compat.v1.app.flags.DEFINE_integer('max_image_width',None,
                             """Maximum allowable input image width""")
-tf.app.flags.DEFINE_integer('min_string_length',None,
+tf.compat.v1.app.flags.DEFINE_integer('min_string_length',None,
                             """Minimum allowable input string length""")
-tf.app.flags.DEFINE_integer('max_string_length',None,
+tf.compat.v1.app.flags.DEFINE_integer('max_string_length',None,
                             """Maximum allowable input string_length""")
 
-tf.app.flags.DEFINE_boolean('static_data', True,
+tf.compat.v1.app.flags.DEFINE_boolean('static_data', True,
                             """Whether to use static data 
                             (false for dynamic data)""")
-tf.app.flags.DEFINE_string('train_path','../data/train/',
+tf.compat.v1.app.flags.DEFINE_string('train_path','../data/train/',
                            """Base directory for training data""")
-tf.app.flags.DEFINE_string('filename_pattern','words-*',
+tf.compat.v1.app.flags.DEFINE_string('filename_pattern','words-*',
                            """File pattern for input data""")
 
-tf.app.flags.DEFINE_string('synth_config_file', None,
+tf.compat.v1.app.flags.DEFINE_string('synth_config_file', None,
                            """Location of config file for map text synthesizer""")
-tf.app.flags.DEFINE_boolean('ipc_synth',True,
+tf.compat.v1.app.flags.DEFINE_boolean('ipc_synth',True,
                             """Use multi-process dynamic image synthesis""")
 
 
 # For displaying various statistics while training
-tf.logging.set_verbosity( tf.logging.INFO )
+tf.compat.v1.logging.set_verbosity( tf.compat.v1.logging.INFO )
 
 
 def _get_input():
@@ -146,9 +146,11 @@ def _get_distribution_strategy():
 def _get_config():
     """Setup config to soften device placement and set chkpt saving intervals"""
     
-    device_config=tf.ConfigProto(
+    device_config=tf.compat.v1.ConfigProto(
         allow_soft_placement=True, 
         log_device_placement=False)
+
+    device_config.gpu_options.allow_growth = True
 
     custom_config = tf.estimator.RunConfig(
         session_config=device_config,
@@ -176,7 +178,7 @@ def main( argv=None ):
                                          model_dir=FLAGS.output )
    
     # Train the model
-    classifier.train( input_fn=_get_input, max_steps=FLAGS.max_num_steps )
+    classifier.train( input_fn=_get_input, max_steps=FLAGS.max_num_steps)
 
 if __name__ == '__main__':
-    tf.app.run()
+    tf.compat.v1.app.run()

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,7 +29,6 @@ import tensorflow as tf
 # available at http://www.apache.org/licenses/LICENSE-2.0, while the
 # derivative work is licensed under GPLv3, to the maximum extent warranted by
 # the original license.
-from tensorflow.contrib.layers.python.layers import utils as layers_utils
 
 def dense_to_sparse_tight(tensor, eos_token=0,
                           outputs_collections=None, scope=None):
@@ -42,16 +41,16 @@ def dense_to_sparse_tight(tensor, eos_token=0,
      outputs_collections: Collection to add the outputs.
      scope: Optional scope for name_scope.
     """
-    with tf.variable_scope(scope, 'dense_to_sparse_tight', [tensor]) as sc:
-        tensor = tf.convert_to_tensor(tensor)
-        indices = tf.where(
+    with tf.compat.v1.variable_scope(scope, 'dense_to_sparse_tight', [tensor]) as sc:
+        tensor = tf.convert_to_tensor(value=tensor)
+        indices = tf.compat.v1.where(
             tf.math.not_equal(tensor, tf.constant(eos_token,
                                                 tensor.dtype)))
         # Need to verify there are *any* indices that are not eos_token
         # If none, give shape [1,0].
-        shape = tf.cond( tf.not_equal(tf.shape(indices)[0],
+        shape = tf.cond( pred=tf.not_equal(tf.shape(input=indices)[0],
                                       tf.constant(0)), # Found valid indices?
-                         true_fn=lambda: tf.cast(tf.reduce_max(indices,axis=0),\
+                         true_fn=lambda: tf.cast(tf.reduce_max(input_tensor=indices,axis=0),\
                                                  tf.int64) + 1,
                          false_fn=lambda: tf.cast([1,0], tf.int64) )
         values = tf.gather_nd(tensor, indices)

--- a/src/validate.py
+++ b/src/validate.py
@@ -40,7 +40,7 @@ tf.app.flags.DEFINE_float( 'lexicon_prior',None,
 			    """Prior bias [0,1] for lexicon word""" )
 
 
-tf.logging.set_verbosity( tf.logging.INFO )
+tf.compat.v1.logging.set_verbosity( tf.compat.v1.logging.INFO )
 
 
 def _get_image( filename ):
@@ -80,7 +80,7 @@ def _get_input():
 def _get_config():
     """Setup session config to soften device placement"""
 
-    device_config=tf.ConfigProto(
+    device_config=tf.compat.v1.ConfigProto(
         allow_soft_placement=True, 
         log_device_placement=False )
 
@@ -113,4 +113,4 @@ def main(argv=None):
             sys.exit()
     
 if __name__ == '__main__':
-    tf.app.run()
+    tf.compat.v1.app.run()


### PR DESCRIPTION
As noted in my commits this code is now Tensorflow 2.0 Compliant. Although it is not fully converted to 2.0; it has some pending depreciations that do not have a set removal version currently. Additionally it has 2 new files evaluation.py and evaluation2.py which is to allow the model to continue to use bidirectional_dynamicrnn and optimize_loss (They are just the files constructing the two contrib modules that were depreciated). Tensorboard indicates this is 99% GPU compliant. 

Note: This is not setup for eager nor any major changes from based code. It is just a hacked together conversion to utilize the native speed boosts from newer drivers.

Dependencies:
Python 3.x (Currently using Python 3.6 with this repository)
Tensorflowgpu 2.0
CUDA 10.0 ***NOT 10.1***
CUDNN 7.3.1 (Note: I believe you can go up to 7.5 although you'd have to fresh compile tensorflow as it is built with 7.3.1 currently)
TensorRT 5.0.2.6
**Linux Nvidia Driver 410.10 -- Unsure if backwards and forwards compatible on windows.