### PR TITLE
fixed inconsistent whitespace

### DIFF
--- a/src/model_fn.py
+++ b/src/model_fn.py
@@ -329,7 +329,7 @@ def _get_output( rnn_logits, sequence_length, lexicon, lexicon_prior ):
        seq_prob: Score of prediction
     """
     with tf.name_scope("test"):
-	if lexicon:
+        if lexicon:
             ctc_blank = (rnn_logits.shape[2]-1)
             lex_prediction,lex_seq_prob = _get_lexicon_output(rnn_logits,
                                                       sequence_length, lexicon )
@@ -365,7 +365,7 @@ def _get_output( rnn_logits, sequence_length, lexicon, lexicon_prior ):
                 eos_token=ctc_blank )
             # (2) CTCWordBeamSearch returns only top match, so convert to list
             prediction = [prediction]
-	else:
+        else:
             prediction, seq_prob = _get_open_output(rnn_logits, sequence_length)
             
     return prediction, seq_prob


### PR DESCRIPTION
two lines used tabs instead of whitespaces, making the model unable to run.